### PR TITLE
Fixed exception when saving configuration with "keep build forever" in it

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
@@ -10,6 +10,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -18,6 +19,9 @@ public class KeepBuildForeverAction extends Notifier {
     
     @Extension
     public static final KeepBuildForeverDescriptor DESCRIPTOR = new KeepBuildForeverDescriptor();
+
+    @DataBoundConstructor
+    public KeepBuildForeverAction() { }
     
     private static final Result PROMOTION_RESULT_MUST_BE_AT_LEAST = Result.UNSTABLE;
     


### PR DESCRIPTION
Hey Pete,
Sorry, not sure what has changed where, but I just added a no args DataBoundConstructor which seems to have fixed it.

Bap.

PS. I have not had a chance to "kick the tires" of your changes, but, from what I can see they look fantastic.
Great job!
