### PR TITLE
Add an option to SelfPromotionCondition to promote only successfull builds

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/config.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry>
+    <f:checkbox name="promotion.selfpromotion.onSuccessOnly" checked="${instance.onSuccessOnly}"/>
+    <label class="attach-previous">${%Trigger only on build success}</label>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
This should be a solution to bug https://issues.jenkins-ci.org/browse/JENKINS-10293
