### PR TITLE
Added Promotion History per Promotion Process at Project's Promotion Status page.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
@@ -96,6 +96,22 @@ public final class PromotedBuildAction implements BuildBadgeAction {
     }
 
     /**
+     * Gets the read-only view of all the promotion builds that this build achieved 
+     * for a PromotionProcess.
+     */
+    public List<Promotion> getPromotionBuilds(PromotionProcess promotionProcess) {
+    	List<Promotion> filtered = new ArrayList<Promotion>();
+    	
+    	for(Status s: getPromotions() ){
+    		if( s.isFor(promotionProcess)){
+    			filtered.addAll( s.getPromotionBuilds() );
+    		}
+    	}
+        return filtered;
+    }
+
+    
+    /**
      * Finds the {@link Status} that has matching {@link Status#name} value.
      * Or null if not found.
      */

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
@@ -6,6 +6,7 @@ import hudson.model.PermalinkProjectAction;
 import hudson.model.ProminentProjectAction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -13,7 +14,11 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 public class PromotedProjectAction implements ProminentProjectAction, PermalinkProjectAction {
-    public final AbstractProject<?,?> owner;
+	
+	//TODO externalize to a plugin property?
+	private static final int SUMMARY_SIZE = 10;
+	
+	public final AbstractProject<?,?> owner;
     private final JobPropertyImpl property;
 
     public PromotedProjectAction(AbstractProject<?, ?> owner, JobPropertyImpl property) {
@@ -24,23 +29,56 @@ public class PromotedProjectAction implements ProminentProjectAction, PermalinkP
     public List<PromotionProcess> getProcesses() {
         return property.getActiveItems();
     }
+    
+    public PromotionProcess getProcess(String name) {
+    	for (PromotionProcess pp : getProcesses() ){
+    		if(pp.getName().equals(name))
+    			return pp;
+    	}
+        return null;
+    }
 
     public AbstractBuild<?,?> getLatest(PromotionProcess p) {
-        return getLatest(p.getName());
+    	List<Promotion> list = getPromotions( p );
+        return list.size() > 0 ? list.get(0) : null;
     }
 
     /**
      * Finds the last promoted build under the given criteria.
      */
     public AbstractBuild<?,?> getLatest(String name) {
-        for( AbstractBuild<?,?> build : owner.getBuilds() ) {
-            PromotedBuildAction a = build.getAction(PromotedBuildAction.class);
-            if(a!=null && a.contains(name))
-                return build;
-        }
-        return null;
+    	List<Promotion> list = getPromotions( getProcess(name) );
+        return list.size() > 0 ? list.get(0) : null;
     }
 
+
+    public List<Promotion> getPromotions(PromotionProcess promotionProcess){
+    	List<Promotion> list = new ArrayList<Promotion>(); 
+        for( AbstractBuild<?,?> build : owner.getBuilds() ) {
+            PromotedBuildAction a = build.getAction(PromotedBuildAction.class);
+            if(a!=null && a.contains(promotionProcess))
+            	list.addAll( a.getPromotionBuilds(promotionProcess) );
+        }
+        Collections.sort(list);
+        return list;
+    }
+    
+    /**
+     * returns the summary of the latest promotions for a promotion process.
+     * 
+     * @param promotionProcessName
+     * @return
+     */
+    public List<Promotion> getPromotionsSummary(PromotionProcess promotionProcess){
+    	List<Promotion> promotionList = this.getPromotions(promotionProcess);
+    	if(promotionList.size() > SUMMARY_SIZE ){
+    		return promotionList.subList(0, SUMMARY_SIZE);
+    	}else{
+    		return promotionList;
+    	}
+    }
+    
+    
     public List<Permalink> getPermalinks() {
         List<Permalink> r = new ArrayList<Permalink>();
         for (PromotionProcess pp : property.getActiveItems())

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -27,7 +27,8 @@ import java.util.List;
  *
  * @author Kohsuke Kawaguchi
  */
-public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
+public class Promotion extends AbstractBuild<PromotionProcess,Promotion> 
+	implements Comparable<Promotion>{
 
     public Promotion(PromotionProcess job) throws IOException {
         super(job);
@@ -171,4 +172,10 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     //public static final Permission PROMOTE = new Permission(PERMISSIONS, "Promote", Messages._Promotion_PromotePermission_Description(), Hudson.ADMINISTER);
     public static final PermissionGroup PERMISSIONS = new PermissionGroup(Promotion.class, null);
     public static final Permission PROMOTE = new Permission(PERMISSIONS, "Promote", null, Hudson.ADMINISTER);
+    
+    @Override
+    public int compareTo(Promotion that) {
+    	return that.getId().compareTo( this.getId() );
+    }
+    
 }

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
@@ -10,22 +10,43 @@
           <img src="${rootURL}/plugin/promoted-builds/icons/32x32/${c.getIcon()}.gif"/> ${c.name}
         </h2>
         
+        <!-- history of this promotion process -->
+        <l:pane title="${%Promotion History}" width="90">
+          <j:forEach var="attempt" items="${it.getPromotionsSummary(c)}">
+            <tr><td>
+              <a href="../${attempt.target.number}/promotion/${c.name}/promotionBuild/${attempt.number}/">
+                <img src="${imagesURL}/16x16/${attempt.buildStatusUrl}"
+                 alt="${attempt.iconColor.description}"/> ${c.name} #${attempt.number}
+              </a>
+              	promoted build
+              	<a href="../${attempt.target.number}/"> 
+              		 #${attempt.target.number}
+              	</a>
+              	on ${attempt.time}
+            </td></tr>
+          </j:forEach>
+        </l:pane>
+        
+        <!-- permalink last promotion -->
         <j:set var="b" value="${it.getLatest(c)}" />
-        <j:choose>
-          <j:when test="${b!=null}">
-            <p>
-              Last promoted build is <t:buildLink job="${b.project}" number="${b.number}" />,
-              ${b.timestampString} ago.
-              (<a href="latest/${c.name}/">permalink</a>)
-            </p>
-          </j:when>
-          <j:otherwise>
-            <p>
-              No build promoted so far.
-            </p>
-          </j:otherwise>
-        </j:choose>
+	    <j:choose>
+	      <j:when test="${b!=null}">
+	        <p>
+	          Last promoted build is <t:buildLink job="${b.project}" number="${b.number}" />
+	          (<a href="latest/${c.name}/">permalink</a>)
+	        </p>
+	      </j:when>
+	      <j:otherwise>
+	        <p>
+	          No build promoted so far.
+	        </p>
+	      </j:otherwise>
+	    </j:choose>
+	    
       </j:forEach>
+      
+
+      
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
[FIXED JENKINS-10447] Added Promotion History per Promotion Process at Project's Promotion Status page.
[FIXED JENKINS-10448] Fixed the Latest Promotion perma link and page's reference
