### PR TITLE
Pass through all the build actions

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -302,13 +302,13 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
     public boolean scheduleBuild(AbstractBuild<?,?> build, Cause cause) {
         assert build.getProject()==getOwner();
 
-        // Get the parameters, if any, used in the target build and make these
-        // available as part of the promotion steps
-        List<ParametersAction> parameters = build.getActions(ParametersAction.class);
+        //Get all of the builds actions
+        List<Action> buildsActions = build.getActions();
+
 
         // Create list of actions to pass to scheduled build
         List<Action> actions = new ArrayList<Action>();
-        actions.addAll(parameters);
+        actions.addAll(buildsActions); //Pass through the original actions
         actions.add(new PromotionTargetAction(build));
 
         // remember what build we are promoting


### PR DESCRIPTION
Adjusted scheduleBuild to pass through all the build actions to the promotion build. This change is passing all the tests and allows the pass the git revision through to another build using the parameterized build plugin. 

https://groups.google.com/d/topic/jenkinsci-dev/VFQsTn1lAF8/discussion
