### PR TITLE
Added a parameterized self promotion process.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge.java
@@ -1,0 +1,15 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package hudson.plugins.promoted_builds.conditions;
+
+import hudson.plugins.promoted_builds.PromotionBadge;
+
+/**
+ *
+ * @author grant
+ */
+public class ParameterizedSelfPromotionBadge extends PromotionBadge {
+
+}

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition.java
@@ -1,0 +1,71 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package hudson.plugins.promoted_builds.conditions;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.plugins.promoted_builds.PromotionBadge;
+import hudson.plugins.promoted_builds.PromotionCondition;
+import hudson.plugins.promoted_builds.PromotionConditionDescriptor;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import java.util.Map;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * {@link PromotionCondition} that promotes a build as soon as it's done if a
+ * given parameter has the specified value.
+ *
+ * @author Grant Limberg <glimberg@gmail.com>
+ */
+public class ParameterizedSelfPromotionCondition extends SelfPromotionCondition {
+    private final String parameterName;
+    private final String parameterValue;
+
+    @DataBoundConstructor
+    public ParameterizedSelfPromotionCondition(boolean evenIfUnstable, String parameterName, String parameterValue) {
+        super(evenIfUnstable);
+        this.parameterName = parameterName;
+        this.parameterValue = parameterValue;
+    }
+
+    public String getParameterName()
+    {
+        return parameterName;
+    }
+    
+    public String getParameterValue()
+    {
+        return parameterValue;
+    }
+
+    @Override
+    public PromotionBadge isMet(PromotionProcess promotionProcess, AbstractBuild<?, ?> build) {
+        if(super.isMet(promotionProcess, build) != null) {
+
+            Result r = build.getResult();
+            Map<String, String> vars = build.getBuildVariables();
+            if(vars.containsKey(parameterName) &&
+               ((String)vars.get(parameterName)).equals(parameterValue)) {
+                System.out.println("Matched parameters!");
+                return new ParameterizedSelfPromotionBadge();
+            }
+        }
+        return null;
+    }
+
+
+    @Extension
+    public static final class DescriptorImpl extends PromotionConditionDescriptor {
+        public boolean isApplicable(AbstractProject<?,?> item) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return Messages.ParameterizedSelfPromotionCondition_DisplayName();
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/Messages.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/Messages.properties
@@ -1,4 +1,5 @@
 SelfPromotionCondition.DisplayName=Promote immediately once the build is complete
+ParameterizedSelfPromotionCondition.DisplayName=Promote immediately once the build is complete based on build parameters
 DownstreamPassCondition.DisplayName=When the following downstream projects build successfully
 ManualCondition.DisplayName=Only when manually approved
 UpstreamPromotionCondition.DisplayName=When the following upstream promotions are promoted

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge/index.jelly
@@ -1,0 +1,3 @@
+<div>
+  ${%Automatically promoted immediately after the build because parameter was matched}
+</div>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/config.jelly
@@ -1,0 +1,12 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry>
+    <f:checkbox name="promotion.self.evenIfUnstable" checked="${instance.evenIfUnstable}"/>
+    <label class="attach-previous">${%Trigger even if the build is unstable}</label>
+  </f:entry>
+  <f:entry title="Parameter Name">
+    <f:textbox name="promotion.self.parameterName" value="${instance.parameterName}"/>
+  </f:entry>
+  <f:entry title="Parameter Value">
+    <f:textbox name="promotion.self.parameterValue" value="${instance.parameterValue}"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/help.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/help.html
@@ -1,0 +1,11 @@
+<div>
+    Promote a build as soon as a build is completed if the specified build paramter values match.
+    This mechanism is convenient for associating small additional tasks at the end of the build.
+    Compared to making it a part of the build, the difference is that this makes
+    the additional step retryable, and a failure will not render the whole build as a failure.
+
+    <p>
+    This criteria can be also handy for consistency; say you have a lot of components built uniformly,
+    and many of them have real test jobs hooked up as the downstream promotion criteria, but some of them
+    might not have any. In such a case, you'll want to immediately promote it.
+</div>


### PR DESCRIPTION
If a given build parameter matches the given value, the build is self-promoted.  Otherwise, the promotion is not run.  This allows the user to automatically run different promotion processes based on build paramters.
