### PR TITLE
RedeployBatchTaskPublisher: fix deployment to Maven repo (JENKINS-11766)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version>
+    <version>1.441-SNAPSHOT</version>
   </parent>
 
   <artifactId>promoted-builds</artifactId>

--- a/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
+++ b/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
@@ -1,6 +1,7 @@
 package hudson.plugins.promoted_builds.tasks;
 
 import hudson.Extension;
+import hudson.maven.MavenModuleSetBuild;
 import hudson.maven.RedeployPublisher;
 import hudson.maven.reporters.MavenAbstractArtifactRecord;
 import hudson.model.AbstractBuild;
@@ -23,8 +24,8 @@ public class RedeployBatchTaskPublisher extends RedeployPublisher {
     }
 
     @Override
-    protected MavenAbstractArtifactRecord getAction(AbstractBuild<?,?> build) {
-        return ((Promotion)(AbstractBuild)build).getTarget().getAction(MavenAbstractArtifactRecord.class);
+    protected MavenModuleSetBuild getMavenBuild(AbstractBuild<?,?> build) {
+        return super.getMavenBuild(((Promotion) build).getTarget());
     }
 
     @Extension


### PR DESCRIPTION
Requires a corresponding fix in the maven plugin.

Signed-off-by: Michael Smith msmith@cbnco.com
