### PR TITLE
Fix for https://issues.jenkins-ci.org/browse/JENKINS-12386

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
@@ -1,0 +1,3 @@
+<div>
+  ${%Build failed - cannot be automatically promoted}
+</div>


### PR DESCRIPTION
Very simple fix for a 500 error thrown when viewing the promotion status of a failed build which has the self promotion condition.
