### PR TITLE
fixing 404 when clicking progress bar

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -61,7 +61,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
 
     @Override
     public String getUrl() {
-        return getTarget().getUrl() + "promotion/" + getParent().getName() + "/promotionBuild/" + getNumber();
+        return getTarget().getUrl() + "promotion/" + getParent().getName() + "/promotionBuild/" + getNumber() + "/";
     }
 
     /**


### PR DESCRIPTION
Clicking the progress bar of a promotion in order to view the console output results in a 404 because it's missing a trailing slash on it's base url: "promotion/sca/promotionBuild/14console". This commit adds the slash to the end of the string returned by getUrl in order to match the convention used by other Jenkins objects.
