### PR TITLE
Build promotion parameter

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
@@ -1,0 +1,213 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2103, Peter Hayes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.promoted_builds.parameters;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.Run;
+import hudson.model.SimpleParameterDefinition;
+import hudson.plugins.promoted_builds.JobPropertyImpl;
+import hudson.plugins.promoted_builds.PromotedBuildAction;
+import hudson.plugins.promoted_builds.PromotedProjectAction;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.export.Exported;
+
+/**
+ * Defines a parameter that allows the user to select a promoted build
+ * from a drop down list.
+ *
+ * @author Pete Hayes
+ */
+public class PromotedBuildParameterDefinition extends SimpleParameterDefinition {
+    private final String projectName;
+    private final String promotionProcessName;
+
+    @DataBoundConstructor
+    public PromotedBuildParameterDefinition(String name, String jobName, String process, String description) {
+        super(name, description);
+        this.projectName = jobName;
+        this.promotionProcessName = process;
+    }
+
+    @Override
+    public PromotedBuildParameterValue createValue(StaplerRequest req, JSONObject jo) {
+        PromotedBuildParameterValue value = req.bindJSON(PromotedBuildParameterValue.class, jo);
+        value.setPromotionProcessName(promotionProcessName);
+        value.setDescription(getDescription());
+        return value;
+    }
+
+    public PromotedBuildParameterValue createValue(String value) {
+        PromotedBuildParameterValue p = new PromotedBuildParameterValue(getName(), value, getDescription());
+        p.setPromotionProcessName(promotionProcessName);
+        return p;
+    }
+
+    @Override
+    public PromotedBuildParameterValue getDefaultParameterValue() {
+        List builds = getBuilds();
+
+        if (builds.isEmpty()) {
+            return null;
+        }
+
+        return createValue(((Run) builds.get(0)).getExternalizableId());
+    }
+
+    @Override
+    public ParameterDefinition copyWithDefaultValue(ParameterValue defaultValue) {
+        if (defaultValue instanceof PromotedBuildParameterValue) {
+            PromotedBuildParameterValue value = (PromotedBuildParameterValue) defaultValue;
+            return new PromotedBuildParameterDefinition(getName(), value.getRunId(), value.getPromotionProcessName(), getDescription());
+        } else {
+            return this;
+        }
+    }
+
+    @Exported
+    public String getJobName() {
+        return projectName;
+    }
+
+    @Exported
+    public String getProcess() {
+        return promotionProcessName;
+    }
+
+    public List getBuilds() {
+        List builds = new ArrayList();
+
+        AbstractProject job = (AbstractProject) Jenkins.getInstance().getItem(projectName);
+
+        PromotedProjectAction promotedProjectAction  = job.getAction(PromotedProjectAction.class);
+        if (promotedProjectAction == null) {
+            return builds;
+        }
+
+        for (Iterator iter = job.getBuilds().iterator(); iter.hasNext(); )  {
+            Run run = (Run) iter.next();
+
+            List buildActions = run.getActions(PromotedBuildAction.class);
+            for (int i = 0; i < buildActions.size(); i++) {
+                PromotedBuildAction buildAction = (PromotedBuildAction) buildActions.get(i);
+
+                if (buildAction.contains(promotionProcessName)) {
+                    builds.add(run);
+                    break;
+                }
+            }
+        }
+
+        return builds;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ParameterDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Promoted Build Parameter";
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/promoted-builds/parameter/promotion.html";
+        }
+
+        @Override
+        public ParameterDefinition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return req.bindJSON(PromotedBuildParameterDefinition.class, formData);
+        }
+
+        /**
+         * Checks the job name.
+         */
+        public FormValidation doCheckJobName(@AncestorInPath Item project, @QueryParameter String value ) {
+            project.checkPermission(Item.CONFIGURE);
+
+            if (StringUtils.isNotBlank(value)) {
+                AbstractProject p = Jenkins.getInstance().getItem(value,project,AbstractProject.class);
+                if(p==null)
+                    return FormValidation.error(hudson.tasks.Messages.BuildTrigger_NoSuchProject(value,
+                            AbstractProject.findNearest(value, project.getParent()).getRelativeNameFrom(project)));
+
+            }
+
+            return FormValidation.ok();
+        }
+
+        public AutoCompletionCandidates doAutoCompleteJobName(@QueryParameter String value) {
+            AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+            List<AbstractProject> jobs = Jenkins.getInstance().getItems(AbstractProject.class);
+            for (AbstractProject job: jobs) {
+                if (job.getFullName().startsWith(value)) {
+                    if (job.hasPermission(Item.READ)) {
+                        candidates.add(job.getFullName());
+                    }
+                }
+            }
+            return candidates;
+        }
+
+        /**
+         * Fills in the available promotion processes.
+         */
+        public ListBoxModel doFillProcessItems(@AncestorInPath Job defaultJob, @QueryParameter("jobName") String jobName) {
+            defaultJob.checkPermission(Item.CONFIGURE);
+
+            AbstractProject<?,?> j = null;
+            if (jobName!=null)
+                j = Jenkins.getInstance().getItem(jobName,defaultJob,AbstractProject.class);
+
+            ListBoxModel r = new ListBoxModel();
+            if (j!=null) {
+                JobPropertyImpl pp = j.getProperty(JobPropertyImpl.class);
+                if (pp!=null) {
+                    for (PromotionProcess proc : pp.getActiveItems())
+                        r.add(new Option(proc.getDisplayName(),proc.getName()));
+                }
+            }
+            return r;
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2103, Peter Hayes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.promoted_builds.parameters;
+
+import hudson.model.RunParameterValue;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Represents an instance of a parameter that relates to a specific build that
+ * met the promotion critera.
+ * 
+ * @author Pete Hayes
+ */
+public class PromotedBuildParameterValue extends RunParameterValue {
+    private String promotionProcessName;
+
+    @DataBoundConstructor
+    public PromotedBuildParameterValue(String name, String runId, String description) {
+        super(name, runId, description);
+    }
+
+    public PromotedBuildParameterValue(String name, String runId) {
+        super(name, runId);
+    }
+
+    public String getPromotionProcessName() {
+        return promotionProcessName;
+    }
+
+    public void setPromotionProcessName(String promotionProcessName) {
+        this.promotionProcessName = promotionProcessName;
+    }
+
+    @Override
+    public String getShortDescription() {
+    	return "(PromotedBuildParameterValue) " + getName() + "='" + getRunId() + "'";
+    }
+}

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config.jelly
@@ -1,0 +1,41 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	<f:entry title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox field="name" />
+	</f:entry>
+        <f:entry title="${%Job Name}" help="/plugin/promoted-builds/parameter/help-job.html">
+            <f:textbox field="jobName" />
+        </f:entry>
+        <f:entry title="${%Promotion}" help="/plugin/promoted-builds/parameter/help-promotion.html">
+            <f:select field="process" />
+	</f:entry>
+    <f:entry title="${%Description}" help="/help/parameter/description.html">
+        <f:textarea field="description" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_da.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_da.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc. Kohsuke Kawaguchi. Knud Poulsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Project=Projekt
+Name=Navn
+Description=Beskrivelse

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_de.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_de.properties
@@ -1,0 +1,3 @@
+Name=Name
+Project=Projekt
+Description=Beschreibung

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_es.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_es.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Name=Nombre
+Project=Proyecto
+Description=Descripción

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_fr.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_fr.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Eric Lefevre-Ardant
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Name=Nom
+Description=
+Project=Projet

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_ja.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_ja.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Seiji Sogabe
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Name=\u540D\u524D
+Project=\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8
+Description=\u8AAC\u660E

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_pt_BR.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_pt_BR.properties
@@ -1,0 +1,25 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc., Cleiber Silva
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Project=Projeto
+Name=Nome
+Description=Descri\u00e7\u00e3o

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_ru.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/config_ru.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Project=\u041F\u0440\u043E\u0435\u043A\u0442

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition/index.jelly
@@ -1,0 +1,39 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	<f:entry title="${it.name}" description="${it.description}">
+		<div name="parameter" description="${it.description}">
+			<input type="hidden" name="name" value="${it.name}" />
+            <select name="runId">
+              <j:forEach var="run" items="${it.builds}">
+                <option value="${run.externalizableId}">${run}</option>
+              </j:forEach>
+            </select>
+		</div>
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue/value.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterValue/value.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	<f:entry title="${it.name}" description="${it.description}">
+		<a href="${rootURL}/${it.run.url}">${it.run}</a>
+	</f:entry>
+</j:jelly>

--- a/src/main/webapp/parameter/help-job.html
+++ b/src/main/webapp/parameter/help-job.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Defines the job from which the user can pick runs. The last run achieving the promotion will be the default.
+  </p>
+</div>

--- a/src/main/webapp/parameter/help-promotion.html
+++ b/src/main/webapp/parameter/help-promotion.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    The name of the promotion process that must have been achieved for the build
+    to be available as a selectable build.
+  </p>
+</div>

--- a/src/main/webapp/parameter/promotion.html
+++ b/src/main/webapp/parameter/promotion.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+	Defines a promoted run parameter, where users can pick a single run of a project that has achieved the specified promotion. The absolute url of this run will be exposed as an environment variable, or through variable substitution in some other parts of the configuration. In the build this can be used to query Jenkins for further information.
+  </p>
+</div>


### PR DESCRIPTION
This change allows users to configure a promotion parameter for a job.  The user selects the job and the promotion that must be attained in order for a build in the selected job to appear in the pick list of builds when selecting the parameter value.
