### PR TITLE
use fullName to compare jobs

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionTrigger.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionTrigger.java
@@ -42,7 +42,7 @@ public class PromotionTrigger extends Trigger<AbstractProject> {
     }
 
     public boolean appliesTo(PromotionProcess proc) {
-        return proc.getName().equals(process) && proc.getParent().getOwner().getFullDisplayName().equals(jobName);
+        return proc.getName().equals(process) && proc.getParent().getOwner().getFullName().equals(jobName);
     }
 
     public void consider(Promotion p) {

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -117,17 +117,24 @@ public class DownstreamPassCondition extends PromotionCondition {
         return r;
     }
 
-    /**
-     * Short-cut for {@code getJobList().contains(job)}.
-     */
-    public boolean contains(AbstractProject<?,?> job) {
-        if(!jobs.contains(job.getFullName()))    return false;   // quick rejection test
+    public boolean contains(ItemGroup ctx, AbstractProject<?,?> job) {
+        // quick rejection test
+        if(!jobs.contains(job.getName())) return false;
 
-        for (String name : Util.tokenize(jobs,",")) {
-            if(name.trim().equals(job.getFullName()))
-                return true;
+        String name = job.getFullName();
+        for (AbstractProject<?, ?> project : getJobList(ctx)) {
+            if (project.getFullName().equals(name)) return true;
         }
         return false;
+    }
+
+
+    /**
+     * Short-cut for {@code getJobList().contains(job)}.
+     * @deprecated use {@link #contains(hudson.model.ItemGroup, hudson.model.AbstractProject)}
+     */
+    public boolean contains(AbstractProject<?,?> job) {
+        return contains(Jenkins.getInstance(), job);
     }
 
     public static final class Badge extends PromotionBadge {
@@ -214,7 +221,7 @@ public class DownstreamPassCondition extends PromotionCondition {
                         for (PromotionCondition cond : p.conditions) {
                             if (cond instanceof DownstreamPassCondition) {
                                 DownstreamPassCondition dpcond = (DownstreamPassCondition) cond;
-                                if(dpcond.contains(build.getParent())) {
+                                if(dpcond.contains(j.getParent(), build.getParent())) {
                                     considerPromotion = true;
                                     break;
                                 }


### PR DESCRIPTION
[JENKINS-17955](https://issues.jenkins-ci.org/browse/JENKINS-17955): use ItemGroup context to compute job full name to compare
