### PR TITLE
Add column to show promotion status in dashboard

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionStatusColumn.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionStatusColumn.java
@@ -1,0 +1,47 @@
+package hudson.plugins.promoted_builds;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.views.ListViewColumn;
+import hudson.views.ListViewColumnDescriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PromotionStatusColumn extends ListViewColumn {
+
+    @DataBoundConstructor
+    public PromotionStatusColumn() {
+        super();
+    }
+
+    public List<String> getPromotionIcons(Job job) {
+        List<String> icons = new ArrayList<String>();
+        Run b = job.getLastBuild();
+        PromotedBuildAction a = b.getAction(PromotedBuildAction.class);
+        for(Status s: a.getPromotions() ) {
+            icons.add(s.getIcon("16x16"));
+	}
+        return icons;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+
+        public DescriptorImpl() {
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.PromotionStatusColumn_DisplayName();
+        }
+
+        public boolean shownByDefault() {
+            return false;
+        }
+    }
+
+}

--- a/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
@@ -36,3 +36,4 @@ Promotion.PromotePermission.Description=This permission allows user to use force
 Promotion.RunnerImpl.Promoting = Promoting {0}
 Promotion.RunnerImpl.SchedulingBuild = scheduling build for {0}
 PromotionCause.ShortDescription = Started by promotion {0} for project "{1}", build number {2}
+PromotionStatusColumn.DisplayName = Promotion Status

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <td>
+    <j:forEach var="c" items="${it.getPromotionIcons(job)}">
+      <img src="${rootURL}${c}" border="0"/>
+    </j:forEach>
+  </td>
+</j:jelly>
+

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/columnHeader.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/columnHeader.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <th>
+    ${%PromotionStatusColumn.Header}
+  </th>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/columnHeader.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/columnHeader.properties
@@ -1,0 +1,1 @@
+PromotionStatusColumn.Header=P

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:block>
+        <p>${%This column shows the promotion status of the last build.}</p>
+    </f:block>
+</j:jelly>


### PR DESCRIPTION
Add a column definition that can be used to show the promotion
status of the latest build in the dashboard view.

Signed-off-by: Bart vdr. Meulen <bartvdrmeulen@gmail.com>