### PR TITLE
Don't process build results prematurely

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -80,19 +80,23 @@ public class DownstreamPassCondition extends PromotionCondition {
         OUTER:
         for (AbstractProject<?,?> j : getJobList(build.getProject().getParent())) {
             for( AbstractBuild<?,?> b : build.getDownstreamBuilds(j) ) {
-                Result r = b.getResult();
-                if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
-                    badge.add(b);
-                    continue OUTER;
+                if (!b.isBuilding()) {
+                    Result r = b.getResult();
+                    if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
+                        badge.add(b);
+                        continue OUTER;
+                    }
                 }
             }
 
             if (pdb!=null) {// if fingerprint doesn't have any, try the pseudo-downstream
                 for (AbstractBuild<?,?> b : pdb.listBuilds(j)) {
-                    Result r = b.getResult();
-                    if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
-                        badge.add(b);
-                        continue OUTER;
+                    if (!b.isBuilding()) {
+                        Result r = b.getResult();
+                        if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
+                            badge.add(b);
+                            continue OUTER;
+                        }
                     }
                 }
             }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition.java
@@ -57,9 +57,11 @@ public class SelfPromotionCondition extends PromotionCondition {
 
     @Override
     public PromotionBadge isMet(PromotionProcess promotionProcess, AbstractBuild<?, ?> build) {
-        Result r = build.getResult();
-        if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
-            return new SelfPromotionBadge();
+        if (!build.isBuilding()) {
+            Result r = build.getResult();
+            if ((r == Result.SUCCESS) || (evenIfUnstable && r == Result.UNSTABLE)) {
+                return new SelfPromotionBadge();
+            }
         }
         return null;
     }


### PR DESCRIPTION
For review.

I'd love to have a unit test for this, but didn't manage to write one yet.

Ran into an issue where builds where promoted even though their downstream builds were unstable. Haven't been able to reliably test this yet, but judging from the source this appears to be right. I'll keep an eye on it to see if it happens again with this update, if so I'll update this issue.
