### PR TITLE
Export build display name to promotion job

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -100,6 +100,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
         e.put("PROMOTED_JOB_FULL_NAME", target.getParent().getFullName());
         e.put("PROMOTED_NUMBER", Integer.toString(target.getNumber()));
         e.put("PROMOTED_ID", target.getId());
+        e.put("PROMOTED_DISPLAY_NAME", target.getDisplayName());
         e.put("PROMOTED_USER_NAME", getUserName());
 	 EnvVars envScm = new EnvVars();
         target.getProject().getScm().buildEnvVars( target, envScm );

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentVariablesTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentVariablesTest.java
@@ -52,6 +52,7 @@ public class PromotionEnvironmentVariablesTest {
         
         // Act
         FreeStyleBuild build = project.scheduleBuild2(0).get();
+        build.setDisplayName("1234");
         build.addAction(approvalAction);
         build.save();
         
@@ -63,8 +64,9 @@ public class PromotionEnvironmentVariablesTest {
         // Assert
         assertEquals("Folder/Project", env.get("PROMOTED_JOB_FULL_NAME"));
         assertEquals("Project", env.get("PROMOTED_JOB_NAME"));
-	assertEquals("SYSTEM", env.get("PROMOTED_USER_NAME"));       
- 
+	assertEquals("SYSTEM", env.get("PROMOTED_USER_NAME"));
+        assertEquals("1234", env.get("PROMOTED_DISPLAY_NAME"));
+
         project.delete();
         parent.delete();
     }


### PR DESCRIPTION
Build display name is often more useful than the build id, as
users of things like the Version Number Plugin will generate
meaningful build numbers and set them as the build display
name. Such build numbers will then be the thing that you
actually need during a promotion if your artifact was stored
somewhere other than Jenkins.

Related JIRA ticket: [JENKINS-23565] https://issues.jenkins-ci.org/browse/JENKINS-23565
