### PR TITLE
JENKINS-20492: show re-execute button even when manually approved.

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -34,7 +34,7 @@
         <!-- promotion activity -->
         <h4>Status</h4>
         <div>
-	      	<j:if test="${!p.isManuallyApproved()}">
+          <!-- JENKINS-20492: show re-execute event when manually approved -->
 		      <j:choose>
 		        <j:when test="${it.getPromotionProcess(p.name)!=null and it.canPromote()}">
 		          <form style="float:right" method="post" action="${p.name}/build">
@@ -42,7 +42,6 @@
 		          </form>
 		        </j:when>
 		      </j:choose>
-	        </j:if>
           <j:choose>
             <j:when test="${p.isPromotionSuccessful()}">
               <img src="${imagesURL}/16x16/blue.png" alt="Unstable" width="16" height="16" />


### PR DESCRIPTION
e.g. when promotion process kicks off a script and the script fails.
