### PR TITLE
Fix NPE: getBuilds() should check that .getItem() does not return null

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
@@ -117,6 +117,9 @@ public class PromotedBuildParameterDefinition extends SimpleParameterDefinition 
         List builds = new ArrayList();
 
         AbstractProject job = (AbstractProject) Jenkins.getInstance().getItem(projectName);
+        if (job == null) {
+            return builds;
+        }
 
         PromotedProjectAction promotedProjectAction  = job.getAction(PromotedProjectAction.class);
         if (promotedProjectAction == null) {


### PR DESCRIPTION
e.g. when someone updates the config.xml directly with invalid `projectName`.
