### PR TITLE
[JENKINS-22679] Pass the target build parameters to the promotion build when the promotion build doesn't have its own parameters.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -327,6 +327,10 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
      * @param promotionParams
      */
 	public static void buildParametersAction(List<Action> actions, AbstractBuild<?, ?> build, List<ParameterValue> promotionParams) {
+        if (promotionParams == null) {
+            promotionParams = new ArrayList<ParameterValue>();
+        }
+
 		List<ParameterValue> params=new ArrayList<ParameterValue>();
 		
 		//Add the target build parameters first, if the same parameter is not being provided bu the promotion build

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -394,9 +394,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
         
         List<Action> actions = new ArrayList<Action>();
-        if (params!=null){
-        	Promotion.buildParametersAction(actions, build, params);
-        }
+       	Promotion.buildParametersAction(actions, build, params);
         actions.add(new PromotionTargetAction(build));
 
         // remember what build we are promoting

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
@@ -1,20 +1,19 @@
 package hudson.plugins.promoted_builds.conditions;
 
-import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import hudson.plugins.promoted_builds.JobPropertyImpl;
 import hudson.plugins.promoted_builds.PromotedBuildAction;
 import hudson.plugins.promoted_builds.Promotion;
 import hudson.plugins.promoted_builds.PromotionProcess;
+import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.TestBuilder;
-
-import java.io.IOException;
-import java.util.Arrays;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -132,6 +131,39 @@ public class SelfPromotionTest extends HudsonTestCase {
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertFalse(badge.contains(promo1));
         assertFalse(badge.contains(promo2));
+    }
+
+    @Bug(22679)
+    public void testPromotionEnvironmentShouldIncludeTargetParameters() throws Exception {
+        String paramName = "param";
+
+        FreeStyleProject p = createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition(paramName, "")));
+
+        // promote if the downstream passes
+        JobPropertyImpl promotion = new JobPropertyImpl(p);
+        p.addProperty(promotion);
+
+        PromotionProcess promo1 = promotion.addProcess("promo1");
+        promo1.conditions.add(new SelfPromotionCondition(false));
+
+        // ensure that the data survives the roundtrip
+        configRoundtrip(p);
+
+        // rebind
+        promotion = p.getProperty(JobPropertyImpl.class);
+        promo1 = promotion.getItem("promo1");
+
+        String paramValue = "someString";
+        FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(),
+                new ParametersAction(new StringParameterValue(paramName, paramValue))));
+        // internally, the promotion is still an asynchronous process. It just happens
+        // right away after the build is complete.
+        Thread.sleep(1000);
+
+        // verify that the promotion's environment contains the parameter from the target build.
+        Promotion pb = promo1.getBuildByNumber(1);
+        assertEquals(paramValue, pb.getEnvironment(null).get(paramName, null));
     }
 
     private FixedResultBuilder successfulBuilder() {


### PR DESCRIPTION
This should fix the regression introduced in 2.17.