### PR TITLE
[JENKINS-22679] Populate promotion environment with parent job parameters

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -45,6 +45,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
@@ -307,7 +308,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @throws IOException 
      */
     public Future<Promotion> considerPromotion2(AbstractBuild<?, ?> build) throws IOException {
-		return considerPromotion2(build, (List<ParameterValue>)null);
+        return considerPromotion2(build, Collections.<ParameterValue>emptyList());
 	}
 	
     public Future<Promotion> considerPromotion2(AbstractBuild<?,?> build, List<ParameterValue> params) throws IOException {
@@ -353,7 +354,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      *      Future to track the completion of the promotion.
      */
     public Future<Promotion> promote2(AbstractBuild<?,?> build, Cause cause, Status qualification) throws IOException {
-    	return promote2(build, cause, qualification, null);
+        return promote2(build, cause, qualification, Collections.<ParameterValue>emptyList());
     }
     public Future<Promotion> promote2(AbstractBuild<?,?> build, Cause cause, Status qualification, List<ParameterValue> params) throws IOException {
         PromotedBuildAction a = build.getAction(PromotedBuildAction.class);
@@ -391,12 +392,10 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
     public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause, List<ParameterValue> params) {
         assert build.getProject()==getOwner();
+        assert params != null;
 
-        
         List<Action> actions = new ArrayList<Action>();
-        if (params!=null){
-        	Promotion.buildParametersAction(actions, build, params);
-        }
+        Promotion.buildParametersAction(actions, build, params);
         actions.add(new PromotionTargetAction(build));
 
         // remember what build we are promoting
@@ -405,7 +404,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
     
 
     public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause) {
-        return scheduleBuild2(build, cause, null);
+        return scheduleBuild2(build, cause, Collections.<ParameterValue>emptyList());
     }
 
     public boolean isInQueue(AbstractBuild<?,?> build) {

--- a/src/main/java/hudson/plugins/promoted_builds/Status.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Status.java
@@ -309,9 +309,8 @@ public final class Status {
         
         JSONObject formData = req.getSubmittedForm();
         
-        List<ParameterValue> paramValues=null;
+        List<ParameterValue> paramValues = new ArrayList<ParameterValue>();
         if (formData!=null){
-            paramValues = new ArrayList<ParameterValue>();
             ManualCondition manualCondition=(ManualCondition) getProcess().getPromotionCondition(ManualCondition.class.getName());
             if (manualCondition!=null){
             	List<ParameterDefinition> parameterDefinitions=manualCondition.getParameterDefinitions();
@@ -330,9 +329,6 @@ public final class Status {
                     }
                 }
             }
-        }
-        if (paramValues==null){
-        	paramValues = new ArrayList<ParameterValue>();
         }
         Future<Promotion> f = getProcess().scheduleBuild2(getTarget(), new UserCause(), paramValues);
         if (f==null)

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentOnParameterizedBuildTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentOnParameterizedBuildTest.java
@@ -1,0 +1,65 @@
+package hudson.plugins.promoted_builds;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.TaskListener;
+import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.core.Is.is;
+
+public class PromotionEnvironmentOnParameterizedBuildTest {
+
+	private static final String PARAM_NAME = "paramOne";
+	private static final String PARAM_VALUE = "13.13";
+	private static final String PROMOTION_PROCESS_NAME = "PromoProcess";
+
+	@Rule public JenkinsRule jenkins = new JenkinsRule();
+
+	private FreeStyleProject project;
+
+	@Test
+	public void promotionEnvironmentShouldContainParametersPassedToParentBuild() throws Exception {
+		givenParameterizedProjectToBePromoted();
+		givenPromotionProcessForProject();
+
+		FreeStyleBuild build = jenkins.assertBuildStatusSuccess(project.scheduleBuild2(0));
+
+		Promotion promotion = thenPromotionIsComplete();
+		assertThat(promotion.getEnvironment(TaskListener.NULL).get(PARAM_NAME), is(equalTo(PARAM_VALUE)));
+		assertThat(promotion.getTarget(), is(sameInstance((AbstractBuild) build)));
+	}
+
+	private void givenParameterizedProjectToBePromoted() throws IOException {
+		project = jenkins.createFreeStyleProject();
+		StringParameterDefinition paramOne = new StringParameterDefinition(PARAM_NAME, PARAM_VALUE);
+		project.addProperty(new ParametersDefinitionProperty(paramOne));
+	}
+
+	private void givenPromotionProcessForProject() throws Descriptor.FormException, IOException {
+		JobPropertyImpl promotionJobProperty = new JobPropertyImpl(project);
+		PromotionProcess promotionProcess = promotionJobProperty.addProcess(PROMOTION_PROCESS_NAME);
+		promotionProcess.conditions.add(new SelfPromotionCondition(false));
+		project.addProperty(promotionJobProperty);
+		project.save();
+	}
+
+	private Promotion thenPromotionIsComplete() {
+		JobPropertyImpl promotionProperty = project.getProperty(JobPropertyImpl.class);
+		PromotionProcess promotionProcess = promotionProperty.getItem(PROMOTION_PROCESS_NAME);
+		assertThat(promotionProcess.getBuilds(), hasSize(1));
+		return promotionProcess.getFirstBuild();
+	}
+}


### PR DESCRIPTION
Fix for JENKINS-2267 bug introduced in version 2.17. After the fix promotion environment is properly initialized with parent job parameters, which is crucial for promotion actions triggering parameterized builds.
