### PR TITLE
Change how build is resolved

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -67,7 +67,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
     @Exported
     public AbstractBuild<?,?> getTarget() {
         PromotionTargetAction pta = getAction(PromotionTargetAction.class);
-        return pta.resolve(this);
+        return pta.resolve();
     }
 
     @Override public AbstractBuild<?,?> getRootBuild() {

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -410,7 +410,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
     public boolean isInQueue(AbstractBuild<?,?> build) {
         for (Item item : Hudson.getInstance().getQueue().getItems(this))
-            if (item.getAction(PromotionTargetAction.class).resolve(this)==build)
+            if (item.getAction(PromotionTargetAction.class).resolve()==build)
                 return true;
         return false;
     }

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionTargetAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionTargetAction.java
@@ -2,8 +2,8 @@ package hudson.plugins.promoted_builds;
 
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Hudson;
 import hudson.model.InvisibleAction;
+
 
 /**
  * Remembers what build it's promoting. Attached to {@link Promotion}.
@@ -13,25 +13,17 @@ import hudson.model.InvisibleAction;
 public class PromotionTargetAction extends InvisibleAction {
     private final String jobName;
     private final int number;
+    private final AbstractProject<?, ?> project;
 
     public PromotionTargetAction(AbstractBuild<?,?> build) {
         jobName = build.getParent().getFullName();
         number = build.getNumber();
+        project = build.getProject();
     }
 
     public AbstractBuild<?,?> resolve() {
-        AbstractProject<?,?> j = Hudson.getInstance().getItemByFullName(jobName, AbstractProject.class);
-        if (j==null)    return null;
-        return j.getBuildByNumber(number);
+        return project.getBuildByNumber(number);
     }
 
-    public AbstractBuild<?,?> resolve(PromotionProcess parent) {
-        AbstractProject<?,?> j = parent.getOwner();
-        if (j==null)    return null;
-        return j.getBuildByNumber(number);
-    }
 
-    public AbstractBuild<?,?> resolve(Promotion parent) {
-        return resolve(parent.getParent());
-    }
 }


### PR DESCRIPTION
This would fix i-m-c/jenkins-inheritance-plugin#14 allowing promoted builds to be inherited.  Because the promotion parent isn't the one that built the build ends up hanging indefinetely and breaks any future builds for the child job.  

The only caveat that I have is that I am not sure if keeping the project reference is the right way to do this, or if there is a better way of keeping a reference to the build project.