### PR TITLE
JENKINS-24271: Re-execute and Force permissions must be separated

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
@@ -130,9 +130,12 @@ public final class PromotedBuildAction implements BuildBadgeAction {
         return !statuses.isEmpty();
     }
 
+    //JENKINS-24271 Re-execute and Force permissions must be separated
     public boolean canPromote() {
         return this.getProject().hasPermission(Promotion.PROMOTE);
     }
+
+    public boolean canReExecute() {return this.getProject().hasPermission(Promotion.REEXECUTE); }
 
     /**
      * Gets list of {@link PromotionProcess}s that are not yet attained.

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -302,7 +302,13 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
     }
 
     public static final PermissionGroup PERMISSIONS = new PermissionGroup(Promotion.class, Messages._Promotion_Permissions_Title());
+
+    // JENKINS-24271 Re-execute and Force permissions must be separated
+    // This permission allows users to execute force promotion.
     public static final Permission PROMOTE = new Permission(PERMISSIONS, "Promote", Messages._Promotion_PromotePermission_Description(), Jenkins.ADMINISTER, PermissionScope.RUN);
+
+    // This permission allows users to re-execute promotion.
+    public static final Permission REEXECUTE = new Permission(PERMISSIONS, "ReExecute", Messages._Promotion_ReExecutePermission_Description(), Jenkins.ADMINISTER, PermissionScope.RUN);
 
     @Override
     public int compareTo(Promotion that) {

--- a/src/main/java/hudson/plugins/promoted_builds/Status.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Status.java
@@ -303,7 +303,8 @@ public final class Status {
      * Schedules a new build.
      */
     public void doBuild(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        if(!getTarget().hasPermission(Promotion.PROMOTE))
+        // JENKINS-24271 Re-execute and Force permissions must be separated
+        if(!getTarget().hasPermission(Promotion.REEXECUTE))
             return;
         
         

--- a/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
@@ -32,6 +32,7 @@ KeepBuildForEverAction.console.promotionNotGoodEnough=Promotion build result [{0
 KeepBuildForEverAction.console.keepingBuild=Marking build to keep forever.
 Promotion.Permissions.Title=Promotion
 Promotion.PromotePermission.Description=This permission allows user to use force promotion and re-execution of promotion
+Promotion.ReExecutePermission.Description=This permission allows user to use re-execution of promotion
 
 Promotion.RunnerImpl.Promoting = Promoting {0}
 Promotion.RunnerImpl.SchedulingBuild = scheduling build for {0}

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -36,7 +36,8 @@
         <div>
           <!-- JENKINS-20492: show re-execute event when manually approved -->
 		      <j:choose>
-		        <j:when test="${it.getPromotionProcess(p.name)!=null and it.canPromote()}">
+		      <!-- JENKINS-24271 Re-execute and Force permissions must be separated -->
+		        <j:when test="${it.getPromotionProcess(p.name)!=null and it.canReExecute()}">
 		          <form style="float:right" method="post" action="${p.name}/build">
 		            <f:submit value="${%Re-execute promotion}"/>
 		          </form>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/Badge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/Badge/index.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <l:pane title="${%Manually Approved}" width="100"><tr><td>
     <f:form method="post" action="${h.encode(p.name)}/build" name="build">
         <j:if test="${!p.last.parameterDefinitionsWithValue.isEmpty()}">
@@ -8,9 +8,12 @@
             </j:forEach>
           </f:section>
         </j:if>
-        <f:block>
-          <f:submit value="${%Re-execute promotion}" />
-        </f:block>
+        <!--JENKINS-24271 Re-execute and Force permissions must be separated-->
+        <j:if test="${p.getParent().canReExecute()}">
+            <f:block>
+ 	            <f:submit value="${%Re-execute promotion}" />
+ 	        </f:block>
+        </j:if>
     </f:form>
   </td></tr></l:pane>
 </j:jelly>


### PR DESCRIPTION
Hi,
Following approach is used:
Current "promote" permission is now used as "force" permission(after upgrading plugin all users with "promote" permission will have "force" permission. New permission "re-execute" is added. 