### PR TITLE
[JENKINS-24782] Prevent phantom builds from being scheduled when PromotionProcesses are built directly.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -38,10 +38,14 @@ import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -403,6 +407,11 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         return super.scheduleBuild2(0, cause, actions.toArray(new Action[actions.size()]));
     }
     
+
+    @Override
+    public void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
+        throw HttpResponses.error(404, "Promotion processes may not be build directly");
+    }
 
     public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause) {
         return scheduleBuild2(build, cause, null);

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -410,7 +410,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
     @Override
     public void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
-        throw HttpResponses.error(404, "Promotion processes may not be build directly");
+        throw HttpResponses.error(404, "Promotion processes may not be built directly");
     }
 
     public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause) {


### PR DESCRIPTION

There is quite a bit more work to be done to tidy up the UX for PromotionProcesses, but at least we can prevent people from shooting themselves in the foot.

Now, when a user clicks "Build Now", the Javascript will essentially ignore the 404. This is an improvement over the existing functionality which schedules a phantom build which can only be stopped by restarting Jenkins.

As discussed in [JENKINS-24782](https://issues.jenkins-ci.org/browse/JENKINS-24782), this plugin should also customize the left navigation and the context menu, but "I got a thousand problems and fixing-promoted-builds-plugin-UX-in-general ain't one." 