### PR TITLE
allow promotion badge to be modified by groovy build step of promotion process

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -45,10 +45,13 @@ import java.util.Map.Entry;
  */
 public class Promotion extends AbstractBuild<PromotionProcess,Promotion> 
 	implements Comparable<Promotion>{
+	
+	private String icon;
 
-    public Promotion(PromotionProcess job) throws IOException {
-        super(job);
-    }
+	public Promotion(PromotionProcess job) throws IOException {
+		super(job);
+		this.icon = job.icon;
+	}
 
     public Promotion(PromotionProcess job, Calendar timestamp) {
         super(job, timestamp);
@@ -87,6 +90,13 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
         return getTarget().getAction(PromotedBuildAction.class).getPromotion(getParent().getName());
     }
 
+	public String getIcon() {
+		return icon;
+	}
+
+	public void setIcon(String icon) {
+		this.icon = icon;
+	}
     @Override
     public EnvVars getEnvironment(TaskListener listener) throws IOException, InterruptedException {
         EnvVars e = super.getEnvironment(listener);

--- a/src/main/java/hudson/plugins/promoted_builds/Status.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Status.java
@@ -106,19 +106,24 @@ public final class Status {
     public String getIcon(String size) {
         String baseName;
 
-        PromotionProcess p = getProcess();
-        if (p == null) {
-            // promotion process undefined (perhaps deleted?). fallback to the default icon
-            baseName = "star-gold";
-        } else {
-            Promotion l = getLast();
-            if (l!=null && l.getResult()!= Result.SUCCESS)
-                return Jenkins.RESOURCE_PATH+"/images/"+size+"/error.png";
+		PromotionProcess p = getProcess();
+		if(p == null) {
+			// promotion process undefined (perhaps deleted?). fallback to the default icon
+			baseName = "star-gold";
+		}
+		else {
+			Promotion l = getLast();
+			if(l != null && l.getResult() != Result.SUCCESS)
+				return Jenkins.RESOURCE_PATH + "/images/" + size + "/error.png";
 
-            baseName = p.getIcon();
-        }
-        return Jenkins.RESOURCE_PATH+"/plugin/promoted-builds/icons/"+size+"/"+ baseName +".png";
-    }
+			baseName = l.getIcon();
+			if(baseName == null) {
+				baseName = p.getIcon();
+
+			}
+		}
+		return baseName != null && !"none".equals(baseName) ? Jenkins.RESOURCE_PATH + "/plugin/promoted-builds/icons/" + size + "/" + baseName + ".png" : null;
+	}
 
     /**
      * Gets the build that was qualified for a promotion.

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
@@ -1,11 +1,14 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.hasPromotion()}">
     <j:forEach var="status" items="${it.getPromotions()}">
-      <a href="${link}promotion/">
-        <img width="16" height="16"
-          title="${status.name}"
-          src="${rootURL}${status.getIcon('16x16')}"/>
-      </a>
+      <j:set var="iconUrl" value="${rootURL}${status.getIcon('16x16')}"/>
+      <j:if test="${not empty iconUrl}">
+	      <a href="${link}promotion/">
+	        <img width="16" height="16"
+	          title="${status.name}"
+	          src="${iconUrl}"/>
+	      </a>
+      </j:if>	      
     </j:forEach>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
I wanted to be able to change the icon associated to the build in one of the steps of the promotion process. Currently the plugin allows you define the icon to be displayed on promotion beforehand and it cannot be changed by a groovy build step in the promotion process.

I have added an icon field to promotion class and initialized it with the value of icon from PromotionProcess class. i also modified the Status class to first look for the value of icon in the promotion object and fallback to PromotionProcess object if icon in Promotion object is null.
There is also a check to return null, if the value of icon in Promotion object is set to "none". This is to allow a groovy build step to remove the icon associated with a promoted build.

The change in badge.jelly is to check if the iconUrl is null and only display the badge if the iconUrl is not null