### PR TITLE
[JENKINS-16063] - Inject PROMOTED_USER_ID variable + minor issue fixes

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
@@ -234,14 +234,15 @@ public class ManualCondition extends PromotionCondition {
             if (authenticationName == null)
                 return "N/A";
 
-            User u = User.get(authenticationName, false);
+            User u = User.get(authenticationName, false, null);
             return u != null ? u.getDisplayName() : authenticationName;
         }
 
         @Exported
         public String getUserId() {
-            if (authenticationName == null)
+            if (authenticationName == null) {
                 return "N/A";
+            }
 
             return authenticationName;
         }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
@@ -239,6 +239,14 @@ public class ManualCondition extends PromotionCondition {
         }
 
         @Exported
+        public String getUserId() {
+            if (authenticationName == null)
+                return "N/A";
+
+            return authenticationName;
+        }
+
+        @Exported
         public List<ParameterValue> getParameterValues() {
             return values != null ? values : Collections.EMPTY_LIST;
         }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentVariablesTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionEnvironmentVariablesTest.java
@@ -51,7 +51,8 @@ public class PromotionEnvironmentVariablesTest {
         // Assert
         assertEquals("Folder/Project", env.get("PROMOTED_JOB_FULL_NAME"));
         assertEquals("Project", env.get("PROMOTED_JOB_NAME"));
-	assertEquals("SYSTEM", env.get("PROMOTED_USER_NAME"));
+        assertEquals("SYSTEM", env.get("PROMOTED_USER_NAME"));
+        assertEquals("SYSTEM", env.get("PROMOTED_USER_ID"));
         assertEquals("1234", env.get("PROMOTED_DISPLAY_NAME"));
 
         project.delete();


### PR DESCRIPTION
It's an update of #52

https://issues.jenkins-ci.org/browse/JENKINS-16063

- [x] Inject PROMOTED_USER_ID
- [x] Properly handle <code>UserIdCause</code> and the legacy <code>UserCause</code>
- [x] Avoid NPEs if ManualCondition.Badge getName()/GetId() return null somehow
- [x] Some tests from #52
