### PR TITLE
Provide parameters from manual approval on all promotions

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -311,7 +311,19 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @throws IOException 
      */
     public Future<Promotion> considerPromotion2(AbstractBuild<?, ?> build) throws IOException {
-		return considerPromotion2(build, (List<ParameterValue>)null);
+		LOGGER.fine("Considering the promotion of "+build+" via "+getName()+" without parmeters");
+		// If the build has manual approvals, use the parameters from it
+		List<ParameterValue> params = new ArrayList<ParameterValue>();
+		List<ManualApproval> approvals = build.getActions(ManualApproval.class);
+		for (ManualApproval approval : approvals) {
+			if (approval.name.equals(getName())) {
+				LOGGER.fine("Getting parameters from existing manual promotion");
+				params = approval.badge.getParameterValues();
+				LOGGER.finer("Using paramters: "+params.toString());
+			}
+		}
+
+		return considerPromotion2(build, params);
 	}
 	
     public Future<Promotion> considerPromotion2(AbstractBuild<?,?> build, List<ParameterValue> params) throws IOException {
@@ -324,7 +336,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         if(a!=null && a.contains(this))
             return null;
 
-        LOGGER.fine("Considering the promotion of "+build+" via "+getName());
+        LOGGER.fine("Considering the promotion of "+build+" via "+getName()+" with parameters");
         Status qualification = isMet(build);
         if(qualification==null)
             return null; // not this time

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
@@ -1,3 +1,3 @@
 <div>
-  ${%Build failed - cannot be automatically promoted}
+  ${%Build still in progress or failed - not automatically promoted}
 </div>


### PR DESCRIPTION
If a manual promotion has been done, provide its parameters to any other
type of promotion that may trigger the build.

Reword the SelfPromotionCondition failure text to indicate that the
build may still be in progress.

[FIXED JENKINS-29793]