### PR TITLE
Removed exception throw when calling isFingerprintConfigured

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -427,7 +427,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 // need to think about what the implications are.
 //
     public boolean isFingerprintConfigured() {
-        throw new UnsupportedOperationException();
+        return false;
     }
 
     protected void buildDependencyGraph(DependencyGraph graph) {


### PR DESCRIPTION
This was causing the promotion process to *always* fail when also running
the Build Environment Plugin v1.6.

The Build Environment Plugin will always check if a process has fingerprint
enabled, and this would always throw an exception. The dummy implementation
the fingerprint method should just return false.