### PR TITLE
[FIXED JENKINS-13751] - PromotionProcess returns SCM of its owner

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -30,6 +30,7 @@ import hudson.model.Saveable;
 import hudson.model.labels.LabelAtom;
 import hudson.model.labels.LabelExpression;
 import hudson.plugins.promoted_builds.conditions.ManualCondition.ManualApproval;
+import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
@@ -108,6 +109,11 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
             bc.abort();
         }
         return p;
+    }
+
+    @Override
+    public SCM getScm() {
+        return this.getOwner().getScm();
     }
 
     @Override


### PR DESCRIPTION
getSCM() in a promoted process will return the base SCM