### PR TITLE
Allow to hide some promotion processes based on parameter value.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/LastBuildPromotionStatusColumn.java
+++ b/src/main/java/hudson/plugins/promoted_builds/LastBuildPromotionStatusColumn.java
@@ -32,7 +32,10 @@ public class LastBuildPromotionStatusColumn extends ListViewColumn {
             PromotedBuildAction a = b != null ? b.getAction(PromotedBuildAction.class) : null;
             if (a != null) {
                 for (Status s : a.getPromotions()) {
-                    icons.add(s.getIcon("16x16"));
+                	PromotionProcess process = s.getProcess();
+                	if (process !=null && process.isVisible()){
+                		icons.add(s.getIcon("16x16"));
+                	}
                 }
             }
         }

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -3,6 +3,7 @@ package hudson.plugins.promoted_builds;
 import antlr.ANTLRException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractBuild;
@@ -22,11 +23,14 @@ import hudson.model.ItemGroup;
 import hudson.model.JDK;
 import hudson.model.Job;
 import hudson.model.Label;
+import hudson.model.ParameterDefinition;
 import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PermalinkProjectAction.Permalink;
 import hudson.model.Queue.Item;
 import hudson.model.Run;
 import hudson.model.Saveable;
+import hudson.model.StringParameterValue;
 import hudson.model.labels.LabelAtom;
 import hudson.model.labels.LabelExpression;
 import hudson.plugins.promoted_builds.conditions.ManualCondition.ManualApproval;
@@ -74,12 +78,16 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * and ${rootURL}/plugin/promoted-builds/icons/32x32/, e.g. <code>"star-gold"</code>.
      */
     public String icon;
-    
+
     /**
      * The label that promotion process can be run on.
      */
     public String assignedLabel;
-    
+    /**
+     * Tells if this promotion should be hidden.
+     */
+    public String isVisible;
+
     private List<BuildStep> buildSteps = new ArrayList<BuildStep>();
 
     /*package*/ PromotionProcess(JobPropertyImpl property, String name) {
@@ -128,6 +136,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         } else {
             assignedLabel = null;
         }
+        isVisible = c.getString("isVisible");
         save();
     }
 
@@ -138,9 +147,9 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      */
     @Override
     public AbstractProject getRootProject() {
-    	return getParent().getOwner().getRootProject();
+        return getParent().getOwner().getRootProject();
     }
-    
+
     @Override
     public JobPropertyImpl getParent() {
         return (JobPropertyImpl)super.getParent();
@@ -179,7 +188,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
         return null;
     }
-    
+
     public DescribableList<Publisher, Descriptor<Publisher>> getPublishersList() {
         // TODO: extract from the buildsSteps field? Or should I separate builders and publishers?
         return new DescribableList<Publisher,Descriptor<Publisher>>(this);
@@ -207,7 +216,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
             return LabelAtom.escape(assignedLabel);
         }
     }
-   
+
     @Override public Label getAssignedLabel() {
         // Really would like to run on the exact node that the promoted build ran on,
         // not just the same label.. but at least this works if job is tied to one node:
@@ -232,7 +241,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
             return ((FreeStyleProject) p).getCustomWorkspace();
         return null;
     }
-    
+
     /**
      * Get the icon name, without the extension. It will always return a non null
      * and non empty string, as <code>"star-gold"</code> is used for compatibility
@@ -241,9 +250,52 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @return the icon name
      */
     public String getIcon() {
-    	return getIcon(icon);
+        return getIcon(icon);
     }
 
+    public String getIsVisible(){
+    	return isVisible;
+    }
+    
+    public boolean isVisible(){
+    	if (isVisible == null) return true;
+    	
+    	AbstractProject<?, ?> job = getOwner();
+    	
+    	if (job == null) return true;
+    	
+    	String expandedIsVisible = isVisible;
+    	EnvVars environment = getDefaultParameterValuesAsEnvVars(job);
+    	if (environment != null){
+    		expandedIsVisible = environment.expand(expandedIsVisible);
+    	}
+   	
+    	if (expandedIsVisible == null){
+    		return true;
+    	}
+    	if (expandedIsVisible.toLowerCase().equals("false")){
+    		return false;
+    	}
+    	return true;
+    }
+    private static EnvVars getDefaultParameterValuesAsEnvVars(AbstractProject owner) {
+    	EnvVars envVars = null;
+		ParametersDefinitionProperty parametersDefinitionProperty = (ParametersDefinitionProperty)owner.getProperty(ParametersDefinitionProperty.class);
+		if (parametersDefinitionProperty!=null){
+			envVars = new EnvVars();
+			for (ParameterDefinition parameterDefinition: parametersDefinitionProperty.getParameterDefinitions()){
+				ParameterValue defaultParameterValue = parameterDefinition.getDefaultParameterValue();
+				if (defaultParameterValue!=null){
+					if (defaultParameterValue instanceof StringParameterValue){
+						envVars.put(parameterDefinition.getName(), ((StringParameterValue)defaultParameterValue).value);
+					}
+				}
+			}
+			EnvVars.resolve(envVars);
+		}
+		
+		return envVars;
+    }
     /**
      * Handle compatibility with pre-1.8 configs.
      * 
@@ -253,9 +305,9 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @return the icon file name for this promotion
      */
     private static String getIcon(String sIcon) {
-    	if ((sIcon == null) || sIcon.equals(""))
+        if ((sIcon == null) || sIcon.equals(""))
             return "star-gold";
-    	else
+        else
             return sIcon;
     }
 
@@ -416,15 +468,14 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
     }
 
     public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause, List<ParameterValue> params) {
-
         List<Action> actions = new ArrayList<Action>();
-       	Promotion.buildParametersAction(actions, build, params);
+        Promotion.buildParametersAction(actions, build, params);
         actions.add(new PromotionTargetAction(build));
 
         // remember what build we are promoting
         return super.scheduleBuild2(0, cause, actions.toArray(new Action[actions.size()]));
     }
-    
+
 
     @Override
     public void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
@@ -442,10 +493,10 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         return false;
     }
 
-//
-// these are dummy implementations to implement abstract methods.
-// need to think about what the implications are.
-//
+    //
+    // these are dummy implementations to implement abstract methods.
+    // need to think about what the implications are.
+    //
     public boolean isFingerprintConfigured() {
         return false;
     }
@@ -624,8 +675,8 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
     private static final Logger LOGGER = Logger.getLogger(PromotionProcess.class.getName());
 
-	public Future<Promotion> considerPromotion2(AbstractBuild<?, ?> build, ManualApproval approval) throws IOException {
-		return considerPromotion2(build, approval.badge.getParameterValues());
-	}
+    public Future<Promotion> considerPromotion2(AbstractBuild<?, ?> build, ManualApproval approval) throws IOException {
+        return considerPromotion2(build, approval.badge.getParameterValues());
+    }
 
 }

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
@@ -1,11 +1,13 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.hasPromotion()}">
     <j:forEach var="status" items="${it.getPromotions()}">
-      <a href="${link}promotion/">
-        <img width="16" height="16"
-          title="${status.name}"
-          src="${rootURL}${status.getIcon('16x16')}"/>
-      </a>
+      <j:if test="${status.getProcess()!=null and status.getProcess().isVisible()}">
+          <a href="${link}promotion/">
+            <img width="16" height="16"
+              title="${status.name}"
+              src="${rootURL}${status.getIcon('16x16')}"/>
+          </a>
+      </j:if>
     </j:forEach>
   </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -14,78 +14,86 @@
 
         <!-- list promotions that are already attained -->
         <j:forEach var="p" items="${it.promotions}">
-          <h2>
-            <img src="${rootURL}${p.getIcon('32x32')}"/> ${p.name}
-          </h2>
+          <j:if test="${p.getProcess()!=null and p.getProcess().isVisible()}">
+            <h2>
+              <img src="${resURL}/plugin/promoted-builds/icons/32x32/${p.getProcess().getIcon()}.png"/>
+              <a href="../../promotion/process/${p.name}" class="model-link">${p.name}</a>
+            </h2>
 
-          <!-- history of this promotion -->
-          <l:pane title="${%Promotion History}" width="100">
-            <j:forEach var="attempt" items="${p.promotionBuilds}">
-              <tr><td>
-                <a href="${p.name}/promotionBuild/${attempt.number}/console">
-                  <img src="${imagesURL}/16x16/${attempt.buildStatusUrl}"
-                   alt="${attempt.iconColor.description}"/> ${attempt.displayName} (${attempt.timestamp.time})</a> by ${attempt.userName}
-              </td></tr>
+            <!-- history of this promotion -->
+            <l:pane title="${%Promotion History}" width="100">
+              <j:forEach var="attempt" items="${p.promotionBuilds}">
+                <tr>
+                  <td>
+                    <a href="${p.name}/promotionBuild/${attempt.number}/console">
+                      <img src="${imagesURL}/16x16/${attempt.buildStatusUrl}"
+                       alt="${attempt.iconColor.description}"/> ${attempt.displayName} (${attempt.timestamp.time})
+                    </a> by ${attempt.userName}
+                  </td>
+                </tr>
+              </j:forEach>
+            </l:pane>
+
+            <!-- how did this build qualify for promotion? -->
+            <h4>
+              ${%Qualification}
+              <span style="padding-left:2em"> </span>
+              (promoted ${p.timestampString} ago &#x2014; ${p.getDelayString(it.owner)} after build)
+            </h4>
+            <j:forEach var="b" items="${p.badges}">
+              <st:include it="${b}" page="index.jelly" />
             </j:forEach>
-          </l:pane>
 
-          <!-- how did this build qualify for promotion? -->
-          <h4>
-            ${%Qualification}
-            <span style="padding-left:2em"> </span>
-            (promoted ${p.timestampString} ago &#x2014; ${p.getDelayString(it.owner)} after build)
-          </h4>
-          <j:forEach var="b" items="${p.badges}">
-            <st:include it="${b}" page="index.jelly" />
-          </j:forEach>
-
-          <!-- promotion activity -->
-          <h4>Status</h4>
-          <div>
-            <!-- JENKINS-20492: show re-execute event when manually approved -->
-                <j:choose>
-                  <j:when test="${it.getPromotionProcess(p.name)!=null and it.canPromote()}">
-                    <form style="float:right" method="post" action="${p.name}/build">
-                      <f:submit value="${%Re-execute promotion}"/>
-                    </form>
-                  </j:when>
-                </j:choose>
-            <j:choose>
-              <j:when test="${p.isPromotionSuccessful()}">
-                <img src="${imagesURL}/16x16/blue.png" alt="Unstable" width="16" height="16" />
-                ${%Successfully promoted} (<a href="${p.name}/lastSuccessful">${%log}</a>)
-              </j:when>
-              <j:when test="${!p.isPromotionAttempted()}">
-                ${%Pending promotion}
-                <j:choose>
-                  <j:when test="${p.isInQueue()}">
-                    (${%promotion queued})
-                  </j:when>
-                  <j:otherwise>
-                    <span class="error">(${%promotion not queued. Please re-execute promotion})</span>
-                  </j:otherwise>
-                </j:choose>
-              </j:when>
-              <j:otherwise>
-                <j:choose>
-                  <j:when test="${p.lastFailed == null}">
-                    ${%Promotion in progress} (<a href="${p.name}/lastSuccessful">${%log}</a>)
-                  </j:when>
-                  <j:otherwise>
-                    <img src="${imagesURL}/16x16/red.png" alt="Unstable" width="16" height="16" />
-                    ${%Promotion failed} (<a href="${p.name}/lastFailed">${%log}</a>)
-                  </j:otherwise>
-                </j:choose>
-              </j:otherwise>
-            </j:choose>
-          </div>
+            <!-- promotion activity -->
+            <h4>Status</h4>
+            <div>
+              <!-- JENKINS-20492: show re-execute event when manually approved -->
+              <j:choose>
+                <j:when test="${it.getPromotionProcess(p.name)!=null and it.canPromote()}">
+                  <form style="float:right" method="post" action="${p.name}/build">
+                    <f:submit value="${%Re-execute promotion}"/>
+                  </form>
+                </j:when>
+              </j:choose>
+              <j:choose>
+                <j:when test="${p.isPromotionSuccessful()}">
+                  <img src="${imagesURL}/16x16/blue.png" alt="Unstable" width="16" height="16" />
+                  ${%Successfully promoted} (<a href="${p.name}/lastSuccessful">${%log}</a>)
+                </j:when>
+                <j:when test="${!p.isPromotionAttempted()}">
+                  ${%Pending promotion}
+                  <j:choose>
+                    <j:when test="${p.isInQueue()}">
+                      (${%promotion queued})
+                    </j:when>
+                    <j:otherwise>
+                      <span class="error">(${%promotion not queued. Please re-execute promotion})</span>
+                    </j:otherwise>
+                  </j:choose>
+                </j:when>
+                <j:otherwise>
+                  <j:choose>
+                    <j:when test="${p.lastFailed == null}">
+                      ${%Promotion in progress} (<a href="${p.name}/lastSuccessful">${%log}</a>)
+                    </j:when>
+                    <j:otherwise>
+                      <img src="${imagesURL}/16x16/red.png" alt="Unstable" width="16" height="16" />
+                      ${%Promotion failed} (<a href="${p.name}/lastFailed">${%log}</a>)
+                    </j:otherwise>
+                  </j:choose>
+                </j:otherwise>
+              </j:choose>
+            </div>
+            <div style="clear:both" />
+          </j:if>
         </j:forEach>
-
         <!-- list promotions that are not yet attained -->
         <j:forEach var="p" items="${it.pendingPromotions}">
-          <h2>
-            <img src="${imagesURL}/32x32/star.png"/> ${p.name}
-          </h2>
+          <j:if test="${p.isVisible()}">
+            <h2>
+              <img src="${resURL}/plugin/promoted-builds/icons/32x32/${p.getIcon()}.png"/>
+              <a href="../../promotion/process/${p.name}" class="model-link">${p.name}</a>
+            </h2>
             <j:choose>
               <j:when test="${it.getPromotionProcess(p.name)!=null and it.canPromote()}">
                 <form style="float:right" method="post" action="forcePromotion?name=${p.name}">
@@ -93,31 +101,33 @@
                 </form>
               </j:when>
             </j:choose>
-          <div>
-            ${%This promotion has not happened.}
-          </div>
+            <div>
+              ${%This promotion has not happened.}
+            </div>
 
-          <!-- how did this build qualify for promotion? -->
-          <h4>
-            ${%Met Qualification(s)}
-            <span style="padding-left:2em"> </span>
-          </h4>
-          <j:forEach var="b" items="${p.getMetQualifications(it.owner)}">
-            <st:include it="${b}" page="index.jelly" />
-          </j:forEach>
+            <!-- how did this build qualify for promotion? -->
+            <h4>
+              ${%Met Qualification(s)}
+              <span style="padding-left:2em"> </span>
+            </h4>
+            <j:forEach var="b" items="${p.getMetQualifications(it.owner)}">
+              <st:include it="${b}" page="index.jelly" />
+            </j:forEach>
 
-          <!-- Remaining qualifications -->
-          <h4>
-            ${%Unmet Qualification(s)}
-            <span style="padding-left:2em"> </span>
-          </h4>
-          <j:forEach var="c" items="${p.getUnmetConditions(it.owner)}">
-            <j:set var="pba" value="${it}"/>
-            <st:include it="${c}" page="index.jelly" />
-          </j:forEach>
+            <!-- Remaining qualifications -->
+            <h4>
+              ${%Unmet Qualification(s)}
+              <span style="padding-left:2em"> </span>
+            </h4>
+            <j:forEach var="c" items="${p.getUnmetConditions(it.owner)}">
+              <j:set var="pba" value="${it}"/>
+              <st:include it="${c}" page="index.jelly" />
+            </j:forEach>
+          </j:if>
         </j:forEach>
+      </div>
 
-    </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>
+

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
@@ -14,39 +14,40 @@
 
         <!-- list promotions that are already attained -->
         <j:forEach var="c" items="${it.processes}">
-          <h2>
-            <img src="${resURL}/plugin/promoted-builds/icons/32x32/${c.getIcon()}.png"/> <a href="process/${c.name}" class="model-link">${c.name}</a>
-          </h2>
-
-          <!-- history of this promotion process -->
-          <l:pane title="${%Promotion History}">
-            <j:forEach var="attempt" items="${it.getPromotionsSummary(c)}">
-              <tr>
-                <td class="history-entry">
-                  <img src="${imagesURL}/16x16/${attempt.buildStatusUrl}" alt="${attempt.iconColor.description}"/>
-                  <a href="../${attempt.target.number}/promotion/${c.name}/promotionBuild/${attempt.number}/" class="model-link">${c.name} #${attempt.number}</a>
-                  promoted build <a href="../${attempt.target.number}/" class="model-link"> #${attempt.target.number}</a> on ${attempt.time}
-                </td>
-              </tr>
-            </j:forEach>
-          </l:pane>
-
-          <!-- permalink last promotion -->
-          <j:set var="b" value="${it.getLatest(c)}" />
-          <j:choose>
-            <j:when test="${b!=null}">
-              <p>
-                Last promoted build is <t:buildLink job="${b.project}" number="${b.number}" />
-                (<a href="latest/${c.name}/">permalink</a>)
-              </p>
-            </j:when>
-            <j:otherwise>
-              <p>
-                No build promoted so far.
-              </p>
-            </j:otherwise>
-          </j:choose>
-
+           <j:if test="${c.isVisible()}">
+	          <h2>
+	            <img src="${resURL}/plugin/promoted-builds/icons/32x32/${c.getIcon()}.png"/> <a href="process/${c.name}" class="model-link">${c.name}</a>
+	          </h2>
+	
+	          <!-- history of this promotion process -->
+	          <l:pane title="${%Promotion History}">
+	            <j:forEach var="attempt" items="${it.getPromotionsSummary(c)}">
+	              <tr>
+	                <td class="history-entry">
+	                  <img src="${imagesURL}/16x16/${attempt.buildStatusUrl}" alt="${attempt.iconColor.description}"/>
+	                  <a href="../${attempt.target.number}/promotion/${c.name}/promotionBuild/${attempt.number}/" class="model-link">${c.name} #${attempt.number}</a>
+	                  promoted build <a href="../${attempt.target.number}/" class="model-link"> #${attempt.target.number}</a> on ${attempt.time}
+	                </td>
+	              </tr>
+	            </j:forEach>
+	          </l:pane>
+	
+	          <!-- permalink last promotion -->
+	          <j:set var="b" value="${it.getLatest(c)}" />
+	          <j:choose>
+	            <j:when test="${b!=null}">
+	              <p>
+	                Last promoted build is <t:buildLink job="${b.project}" number="${b.number}" />
+	                (<a href="latest/${c.name}/">permalink</a>)
+	              </p>
+	            </j:when>
+	            <j:otherwise>
+	              <p>
+	                No build promoted so far.
+	              </p>
+	            </j:otherwise>
+	          </j:choose>
+           </j:if>
         </j:forEach>
       </div>
     </l:main-panel>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/help-isVisible.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/help-isVisible.html
@@ -1,0 +1,20 @@
+<div>
+	If you are using Inheritance Projects you can define promotions in base job. 
+	You can then choose some of the promotion processes to be visible in some derived jobs but not others. 
+	If parameter Visible evaluates to "true" or is empty, then it is visible, it is not visible otherwise. 
+	You can also use parameters, e.g. ${PARAMETER_NAME} to reference other parameters. 
+	Note that only default values of the parameters are evaluated, i.e. parameters of the jobs, not the builds are taken into account.	
+
+    <p>
+    
+
+    <h3> Example configuration</h3>
+    <ul>
+    <li><b>BASE</b> job which configures promotion process <b>Promotion</b> and also has inheritable parameter <b>IsPromotionVisible</b>. 
+    <b>Visible</b> property is set to reference <b>IsPromotionVisible</b>, i.e. its value is ${IsPromotionVisible}
+    It also makes sense to hide this parameter from the build screen by selecting <b>Hide behind button on build screen?</b> checkbox in advanced parameter properties.  
+    <li><b>DERIVEDEnabled</b> job which inherits from <b>BASE</b> but also references  <b>IsPromotionVisible</b> parameter and sets its default value to true.
+	<li><b>DERIVEDDisabled</b> job which inherits from <b>BASE</b> but also references  <b>IsPromotionVisible</b> parameter and sets its default value to false.
+	</ul>
+	In this configuration <b>DERIVEDEnabled</b> will show promotion <b>Promotion</b> but <b>DERIVEDDisabled</b> will not show it.
+</div>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
@@ -5,6 +5,9 @@
       <f:entry title="Name" field="name">
         <f:textbox />
       </f:entry>
+      <f:entry title="Visible" field="isVisible">
+        <f:textbox />
+      </f:entry>
       <f:entry title="Icon">
         <select class="setting-input" name="icon">
           <f:option selected="${instance.icon=='star-gold'}"     value="star-gold">Gold star</f:option>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
@@ -6,29 +6,31 @@
       <j:when test="${ppa!=null}">
         <j:set var="pp" value="${ppa.getPromotionProcesses()}"/>
         <j:forEach var="process" items="${pp}">
-          <j:set var="status" value="${ppa.getStatus(process)}"/>
-          <j:set var="icon" value="${process.getIcon()}"/>
-          <j:set var="iconUrl" value="${resURL}/plugin/promoted-builds/icons/${iconSize}/${icon}.png"/>
-          <img width="${iconSize}" height="${iconSize}"
-            title="${%PromotionProcess} ${process.name}"
-            src="${iconUrl}"/>
-          <j:choose>
-            <j:when test="${status!=null}">
-              <j:if test="${status.isLastAnError()}">
-                <j:set var="iconUrl" value="${resURL}/images/${iconSize}/error.png"/>
-                <img width="${iconSize}" height="${iconSize}"
-                  title="${%PromotionProcess} ${process.name} ${%PromotionProcess.failed}"
-                  src="${iconUrl}"/>
-              </j:if>
-              <j:set var="target" value="${status.getTarget()}"/>
-              <a href="${jobBaseUrl}${job.shortUrl}${target.number}/" class="model-link inside">
-                ${target.displayName}
-              </a>
-            </j:when>
-            <j:otherwise><!-- promotion has never happened / no builds -->
-              ${%Otherwise.noBuild}
-            </j:otherwise>
-          </j:choose>
+           <j:if test="${process.isVisible()}">
+	          <j:set var="status" value="${ppa.getStatus(process)}"/>
+	          <j:set var="icon" value="${process.getIcon()}"/>
+	          <j:set var="iconUrl" value="${resURL}/plugin/promoted-builds/icons/${iconSize}/${icon}.png"/>
+	          <img width="${iconSize}" height="${iconSize}"
+	            title="${%PromotionProcess} ${process.name}"
+	            src="${iconUrl}"/>
+	          <j:choose>
+	            <j:when test="${status!=null}">
+	              <j:if test="${status.isLastAnError()}">
+	                <j:set var="iconUrl" value="${resURL}/images/${iconSize}/error.png"/>
+	                <img width="${iconSize}" height="${iconSize}"
+	                  title="${%PromotionProcess} ${process.name} ${%PromotionProcess.failed}"
+	                  src="${iconUrl}"/>
+	              </j:if>
+	              <j:set var="target" value="${status.getTarget()}"/>
+	              <a href="${jobBaseUrl}${job.shortUrl}${target.number}/" class="model-link inside">
+	                ${target.displayName}
+	              </a>
+	            </j:when>
+	            <j:otherwise><!-- promotion has never happened / no builds -->
+	              ${%Otherwise.noBuild}
+	            </j:otherwise>
+	          </j:choose>
+	       </j:if>
         </j:forEach>
       </j:when>
       <j:otherwise><!-- job has no promotion process (no project action) -->


### PR DESCRIPTION
Add a property "Visible" to promotion processes that resolves parameters (default values of parameters only). If the parameter resolves to false the promotion is not shown in Project, Build and other contexts... 

This is useful in inheritance scenarios where promotion processes are defined in base job (e.g. BASE job has promotion to Dev, Staging, and Production defined) and there are inheriting jobs that just set visibility: e.g.
Stable and Mainline that both inherit from BASE but Stable should show only promotions to Staging and Production and Mainline only to Development. 