### PR TITLE
Sort Promotion By Number

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -368,7 +368,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
 
     @Override
     public int compareTo(Promotion that) {
-    	return that.getId().compareTo( this.getId() );
+    	return that.getNumber().compareTo( this.getNumber() );
     }
 
     @Override


### PR DESCRIPTION
Instead of sorting promotions by Id (e.g. #42), sorts promotions by Number (e.g. 42). Fixes the display of promotion list for a given job.

Here what's displayed before the fix : the "Last promotion Build" is as wrong and the promotion list displayed is not sorted chronologically.
![image](https://cloud.githubusercontent.com/assets/1616208/11595078/fdb07926-9aad-11e5-8c08-dd7700b61a2b.png)