### PR TITLE
[FIXED JENKINS-31908] - Sort Promotion By Number

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -368,7 +368,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
 
     @Override
     public int compareTo(Promotion that) {
-    	return that.getId().compareTo( this.getId() );
+    	return Integer.compare(that.getNumber(),this.getNumber());
     }
 
     @Override


### PR DESCRIPTION
Instead of sorting promotions by id (e.g. #42), sorts promotions by number (e.g. 42). Fixes the display of the promotion list history for a job.
[FIXED JENKINS-31908]
Here is what was displayed : last build is wrong, list is not sorted chronologically.
![image](https://cloud.githubusercontent.com/assets/1616208/11596270/5e54abde-9ab4-11e5-9310-9f9698def233.png)
