### PR TITLE
Add Groovy script condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
       <version>1.5.3</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.16</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
       <version>1.16</version>
-      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyCondition.java
@@ -1,0 +1,142 @@
+package hudson.plugins.promoted_builds.conditions;
+
+import groovy.lang.Binding;
+import hudson.EnvVars;
+import hudson.PluginManager;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.plugins.promoted_builds.PromotionBadge;
+import hudson.plugins.promoted_builds.PromotionCondition;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedClasspathException;
+import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedUsageException;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Allow specification of Groovy scripts to qualify builds. Script evaluation is done using the
+ * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin">Script Security plugin</a>
+ */
+public class GroovyCondition extends PromotionCondition {
+    private static final Logger LOGGER = Logger.getLogger(GroovyCondition.class.getName());
+
+    @CheckForNull
+    private final String unmetQualificationLabel;
+    @CheckForNull
+    private final String metQualificationLabel;
+    private final SecureGroovyScript script;
+
+    @DataBoundConstructor
+    public GroovyCondition(final SecureGroovyScript script, final String unmetQualificationLabel, final String metQualificationLabel) {
+        this.unmetQualificationLabel = Util.fixEmptyAndTrim(unmetQualificationLabel);
+        this.metQualificationLabel = Util.fixEmptyAndTrim(metQualificationLabel);
+        this.script = script.configuringWithNonKeyItem();
+    }
+
+    // exposed for config.jelly
+    public SecureGroovyScript getScript() {
+        return script;
+    }
+
+    // exposed for config.jelly
+    public String getUnmetQualificationLabel() {
+        return unmetQualificationLabel;
+    }
+
+    // exposed for config.jelly
+    public String getMetQualificationLabel() {
+        return metQualificationLabel;
+    }
+
+    // exposed for promotion status page
+    public String getDisplayLabel() {
+        return unmetQualificationLabel == null ? Messages.GroovyCondition_UnmetQualificationLabel() : unmetQualificationLabel;
+    }
+
+    @Override
+    public PromotionBadge isMet(final PromotionProcess promotionProcess, final AbstractBuild<?, ?> build) {
+        // TODO switch to Jenkins.getActiveInstance() once bumped to 1.590
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            // Jenkins not started or shut down
+            LOGGER.log(Level.WARNING, "Missing Jenkins instance");
+            return null;
+        }
+        final PluginManager pluginManager = jenkins.getPluginManager();
+        if (pluginManager == null) {
+            LOGGER.log(Level.WARNING, "Unable to retrieve PluginManager");
+            return null;
+        }
+        final ClassLoader classLoader = pluginManager.uberClassLoader;
+        final Binding binding = new Binding();
+        binding.setVariable("promotionProcess", promotionProcess);
+        binding.setVariable("build", build);
+        binding.setVariable("jenkins", jenkins);
+        Object result = null;
+        try {
+            result = script.evaluate(classLoader, binding);
+        } catch (final RejectedAccessException e) {
+            LOGGER.log(Level.WARNING, "Sandbox exception", e);
+            return null;
+        } catch (final UnapprovedUsageException e) {
+            LOGGER.log(Level.WARNING, "Unapproved script", e);
+            return null;
+        } catch (final UnapprovedClasspathException e) {
+            LOGGER.log(Level.WARNING, "Unapproved classpath", e);
+            return null;
+        } catch (final Exception e) {
+            LOGGER.log(Level.WARNING, "Evaluation error", e);
+            return null;
+        }
+        final String displayLabel = metQualificationLabel == null ? Messages.GroovyCondition_MetQualificationLabel() : metQualificationLabel;
+        if (Boolean.TRUE.equals(result)) {
+            return new Badge(displayLabel, Collections.<String,String>emptyMap());
+        } else if (result instanceof Map && !((Map) result).isEmpty()) {
+            final Map<String, String> variables = new HashMap<String, String>(((Map) result).size());
+            for (final Map.Entry entry : ((Map<Object, Object>) result).entrySet()) {
+                final Object key = entry.getKey();
+                final Object value = entry.getValue();
+                if (key == null) {
+                    continue;
+                }
+                variables.put(key.toString(), value == null ? "" : value.toString());
+            }
+            return new Badge(displayLabel, variables);
+        }
+        return null;
+    }
+
+    public static final class Badge extends PromotionBadge {
+        private final String displayLabel;
+        private final Map<String, String> variables;
+
+        public Badge(final String displayLabel, final Map<String, String> variables) {
+            this.displayLabel = displayLabel;
+            this.variables = variables;
+        }
+
+        // exposed for Jelly
+        public String getDisplayLabel() {
+            return displayLabel;
+        }
+
+        @Override
+        public void buildEnvVars(final AbstractBuild<?, ?> build, final EnvVars env) {
+            super.buildEnvVars(build, env);
+            for (final Map.Entry<String, String> entry :
+                    variables.entrySet()) {
+                env.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyConditionDescriptor.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyConditionDescriptor.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 /**
  * Declared outside GroovyCondition as it depends on the optional 'script-security' dependency
  */
-@Extension
+@Extension(optional = true)
 public final class GroovyConditionDescriptor extends PromotionConditionDescriptor {
 
     private static final Logger LOGGER = Logger.getLogger(GroovyConditionDescriptor.class.getName());

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyConditionDescriptor.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/GroovyConditionDescriptor.java
@@ -1,0 +1,47 @@
+package hudson.plugins.promoted_builds.conditions;
+
+import hudson.Extension;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
+import hudson.model.AbstractProject;
+import hudson.plugins.promoted_builds.PromotionConditionDescriptor;
+import jenkins.model.Jenkins;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Declared outside GroovyCondition as it depends on the optional 'script-security' dependency
+ */
+@Extension
+public final class GroovyConditionDescriptor extends PromotionConditionDescriptor {
+
+    private static final Logger LOGGER = Logger.getLogger(GroovyConditionDescriptor.class.getName());
+
+    public GroovyConditionDescriptor() {
+        super(GroovyCondition.class);
+    }
+
+    @Override
+    public boolean isApplicable(final AbstractProject<?, ?> item) {
+        // TODO switch to Jenkins.getActiveInstance() once bumped to 1.590
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            // Jenkins not started or shut down
+            return false;
+        }
+        final PluginManager pluginManager = jenkins.getPluginManager();
+        if (pluginManager == null) {
+            LOGGER.log(Level.WARNING, "No PluginManager");
+            return false;
+        }
+        final PluginWrapper plugin = pluginManager.getPlugin("script-security");
+        return plugin != null && plugin.isActive();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.GroovyCondition_DisplayName();
+    }
+
+}

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/Badge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/Badge/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  ${it.displayLabel}
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/config.jelly
@@ -1,0 +1,17 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:property field="script"/>
+  <f:advanced>
+    <f:entry
+        field="unmetQualificationLabel"
+        title="${%Display label when condition not met}"
+    >
+      <f:textbox/>
+    </f:entry>
+    <f:entry
+        field="metQualificationLabel"
+        title="${%Display label when condition met}"
+    >
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/help.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/help.html
@@ -1,0 +1,38 @@
+<p>
+  Evaluates a custom Groovy script that can use the full
+  <a href="http://javadoc.jenkins-ci.org/">Jenkins API</a>
+  (including installed plugins) to consider whether a build qualifies.
+  The evaluation is done through the
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin">Script Security plugin</a>.
+</p>
+<p>
+  The script evaluation is not self-triggered and requires to enable a suitable
+  criteria (such as 'Promote immediately once...') in addition to this one.
+</p>
+<p>
+  Available variables are:
+  <ul>
+    <li><code>promotionProcess</code>
+      The promotion process containing the condition (hudson.plugins.promoted_builds.PromotionProcess)
+    </li>
+    <li><code>build</code>
+      The build being considered for promotion
+      (<a href="http://javadoc.jenkins-ci.org/index.html?hudson/model/AbstractBuild.html">hudson.model.AbstractBuild</a>)
+    </li>
+    <li><code>jenkins</code>
+      The
+      <a href="http://javadoc.jenkins-ci.org/index.html?jenkins/model/Jenkins.html">jenkins.model.Jenkins</a>
+      instance
+    </li>
+  </ul>
+</p>
+<p>
+  To signal the qualification of the build, return <code>true</code>
+  or a non-empty <code>java.util.Map&lt;String,String&gt;</code> to contribute to the Promotion
+  environment
+</p>
+<p>
+  Any script evaluation errors are redirected to the
+  <code>hudson.plugins.promoted_builds.conditions.GroovyCondition</code>
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Logging">logger</a>
+</p>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  ${it.displayLabel}
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/Messages.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/Messages.properties
@@ -3,3 +3,6 @@ ParameterizedSelfPromotionCondition.DisplayName=Promote immediately once the bui
 DownstreamPassCondition.DisplayName=When the following downstream projects build successfully
 ManualCondition.DisplayName=Only when manually approved
 UpstreamPromotionCondition.DisplayName=When the following upstream promotions are promoted
+GroovyCondition.DisplayName=Custom Groovy script
+GroovyCondition.UnmetQualificationLabel=Custom Groovy script condition
+GroovyCondition.MetQualificationLabel=Custom Groovy script condition

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/GroovyConditionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/GroovyConditionTest.java
@@ -1,0 +1,80 @@
+package hudson.plugins.promoted_builds.conditions;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.promoted_builds.JobPropertyImpl;
+import hudson.plugins.promoted_builds.PromotionProcess;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class GroovyConditionTest {
+    @Rule
+    public JenkinsRule j =  new JenkinsRule();
+
+    @Test
+    public void testBooleanScript() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        final JobPropertyImpl property = new JobPropertyImpl(p);
+
+        final PromotionProcess promotionProcessTrue = property.addProcess("truePromotion");
+        promotionProcessTrue.conditions.add(new GroovyCondition(new SecureGroovyScript("true", false, null), "", ""));
+
+        final PromotionProcess promotionProcessFalse = property.addProcess("falsePromotion");
+        promotionProcessFalse.conditions.add(new GroovyCondition(new SecureGroovyScript("false", false, null), "", ""));
+
+        p = j.configRoundtrip(p);
+
+        final FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        Assert.assertNotNull("Promotion was expected", promotionProcessTrue.isMet(build));
+        Assert.assertNull("Promotion was not expected", promotionProcessFalse.isMet(build));
+    }
+
+    @Test
+    public void testMapScript() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        final JobPropertyImpl property = new JobPropertyImpl(p);
+
+        final PromotionProcess promotionProcessEmptyMap = property.addProcess("emptyMap");
+        promotionProcessEmptyMap.conditions.add(new GroovyCondition(new SecureGroovyScript("[:]", false, null), "", ""));
+
+        final PromotionProcess promotionProcessNonEmptyMap = property.addProcess("nonEmptyMap");
+        promotionProcessNonEmptyMap.conditions.add(new GroovyCondition(new SecureGroovyScript("[foo: 'bar']", false, null), "", ""));
+
+        p = j.configRoundtrip(p);
+
+        final FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        Assert.assertNull("Promotion was not expected", promotionProcessEmptyMap.isMet(build));
+        Assert.assertNotNull("Promotion was expected", promotionProcessNonEmptyMap.isMet(build));
+    }
+
+    @Test
+    public void testBinding() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        final JobPropertyImpl property = new JobPropertyImpl(p);
+
+        final PromotionProcess promotionProcess = property.addProcess("testPromotion");
+        promotionProcess.conditions.add(
+            new GroovyCondition(
+                new SecureGroovyScript(
+                    "promotionProcess instanceof hudson.plugins.promoted_builds.PromotionProcess && " +
+                        "build instanceof hudson.model.AbstractBuild && " +
+                        "jenkins instanceof jenkins.model.Jenkins",
+                    false,
+                    null
+                ),
+            "",
+            ""
+        ));
+
+        p = j.configRoundtrip(p);
+
+        final FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        Assert.assertNotNull("Promotion was expected", promotionProcess.isMet(build));
+    }
+}


### PR DESCRIPTION
- Allow custom conditions for promotions when `script-security` is installed (1.16 was chosen over 1.17 to avoid bumping Jenkins version).
- That condition does not trigger itself (eg. need to be combined with ManualCondition, SelfPromotionCondition or similar)
- The script can also contribute to the environment of the Promotion build (by returning a Map)
- Can customize the label shown on the promotions status page
