### PR TITLE
[FIXED JENKINS-32993] Expose PROMOTED_TIMESTAMP

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -104,6 +104,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion>
         e.put("PROMOTED_JOB_FULL_NAME", target.getParent().getFullName());
         e.put("PROMOTED_NUMBER", Integer.toString(target.getNumber()));
         e.put("PROMOTED_ID", target.getId());
+        e.put("PROMOTED_TIMESTAMP", target.getTimestampString2());
         e.put("PROMOTED_DISPLAY_NAME", target.getDisplayName());
         e.put("PROMOTED_USER_NAME", getUserName());
         e.put("PROMOTED_USER_ID", getUserId());


### PR DESCRIPTION
Before, `Run.getId()` was returning something like `2012-04-12_17-13-03`, but with the change of [JENKINS-24380](https://wiki.jenkins-ci.org/display/JENKINS/JENKINS-24380+Migration) this is returning just the same than `PROMOTED_NUMBER` env var.

So `PROMOTED_NUMBER= PROMOTED_NUMBER`

```
        e.put("PROMOTED_URL",rootUrl+target.getUrl());
        e.put("PROMOTED_JOB_NAME", target.getParent().getName());
        e.put("PROMOTED_JOB_FULL_NAME", target.getParent().getFullName());
        e.put("PROMOTED_NUMBER", Integer.toString(target.getNumber()));
        e.put("PROMOTED_ID", target.getId());
        e.put("PROMOTED_DISPLAY_NAME", target.getDisplayName());
        e.put("PROMOTED_USER_NAME", getUserName());
        e.put("PROMOTED_USER_ID", getUserId());
````

The correct fix is to maintain `PROMOTED_ID` for backward compatibility and create a new env var called `PROMOTED_TIMESTAMP` which will now expose the timestamp on a standard way, something like *2016-02-17T10:46:14Z*.

https://issues.jenkins-ci.org/browse/JENKINS-32993

@reviewbybees CC @oleg-nenashev 