### PR TITLE
[FIXED JENKINS-33147] Customize Date format string and timezone

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds.java
+++ b/src/main/java/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds.java
@@ -1,0 +1,61 @@
+package hudson.plugins.promoted_builds;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Global Jenkins configuration for Promoted Builds
+ *
+ * @since 2.26
+ */
+
+@Extension
+public class GlobalBuildPromotedBuilds extends GlobalConfiguration {
+
+    /**
+     * By default ISO 8601 like 2016-10-12T09:30Z to be used with
+     * environmental variable $PROMOTED_TIMESTAMP.
+     */
+    private String dateFormat;
+
+    /**
+     * By default Java timezone setting to be used with environmental
+     * variable $PROMOTED_TIMESTAMP.
+     *
+     * Other time zones can be selected if field is filled.
+     */
+    private String timeZone;
+
+    public GlobalBuildPromotedBuilds() {
+        load();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    public static GlobalBuildPromotedBuilds get() {
+        return GlobalBuildPromotedBuilds.all().get(GlobalBuildPromotedBuilds.class);
+    }
+}

--- a/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="Build Pipeline Plugin">
+        <f:entry field="dateFormat" title="Date format">
+            <f:textbox />
+        </f:entry>
+        <f:entry field="timeZone" title="Time zone">
+            <f:textbox />
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/help-dateFormat.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/help-dateFormat.html
@@ -1,0 +1,5 @@
+<div>
+    Used to specify the date format for $PROMOTED_TIMESTAMP.
+    <br/>
+    By default, ISO 8601 formatted presentation of current moment like: 2016-10-12T09:30Z.
+</div>

--- a/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/help-timeZone.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds/help-timeZone.html
@@ -1,0 +1,5 @@
+<div>
+    Used to determinate the TZ for $PROMOTED_TIMESTAMP.
+    <br/>
+    By default, Java time zone.
+</div>


### PR DESCRIPTION
`PROMOTED_TIMESTAMP` shows the date timestamp in UTC TZ but should work in JDK time zone.

I tried to  use the same format than was before for backward compatibility.

```
2012-04-12_17-13-03
```

@reviewbybees @oleg-nenashev 