### PR TITLE
 [FIXED JENKINS-34204] include node attributes when writing job dsl nodes

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
@@ -1,6 +1,7 @@
 package hudson.plugins.promoted_builds.integrations.jobdsl;
 
 import java.util.Collection;
+import java.util.Map;
 
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -15,6 +16,8 @@ import groovy.util.Node;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * XStream Converter for the PromotionProcess for the Job DSL Plugin
@@ -89,6 +92,7 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
 
     private void convertNode(Node node, HierarchicalStreamWriter writer) {
         writer.startNode(node.name().toString());
+        writeNodeAttributes(node, writer);
         if (node.value() instanceof Collection) {
             for (Object subNode : (Collection) node.value()) {
                 convertNode((Node) subNode, writer);
@@ -97,6 +101,17 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
             writer.setValue(node.value().toString());
         }
         writer.endNode();
+    }
+
+    private void writeNodeAttributes(Node node, HierarchicalStreamWriter writer) {
+        Map<?,?> attributes = node.attributes();
+        if (attributes != null) {
+            for (Map.Entry<?,?> entry : attributes.entrySet()) {
+                String key = ObjectUtils.toString(entry.getKey());
+                String value = ObjectUtils.toString(entry.getValue());
+                writer.addAttribute(key, value);
+            }
+        }
     }
 
     private String obtainClassOwnership() {

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
@@ -61,7 +61,6 @@ public class PromotionsDslContextExtensionTest extends HudsonTestCase {
         TopLevelItem item = jenkins.getItem("copy-artifacts-test");
         File config = new File(item.getRootDir(), "promotions/Development/config.xml");
         String content = Files.toString(config, Charset.forName("UTF-8"));
-        System.out.println("CONTENT: " + content);
         assert content.contains("<selector class=\"hudson.plugins.copyartifact.SpecificBuildSelector\">");
     }
 

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
@@ -1,10 +1,14 @@
 package hudson.plugins.promoted_builds.integrations.jobdsl;
 
+import com.google.common.io.Files;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.TopLevelItem;
 import hudson.model.queue.QueueTaskFuture;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import javaposse.jobdsl.plugin.RemovedJobAction;
 import javaposse.jobdsl.plugin.ExecuteDslScripts;
@@ -41,4 +45,24 @@ public class PromotionsDslContextExtensionTest extends HudsonTestCase {
         // Then
         assertBuildStatusSuccess(scheduleBuild2);
     }
+
+    @Test
+    public void testShouldGenerateTheCopyArtifactsJob() throws Exception {
+        // Given
+        String dsl = FileUtils.readFileToString(new File("src/test/resources/copyartifacts-example-dsl.groovy"));
+        FreeStyleProject seedJob = createFreeStyleProject();
+        seedJob.getBuildersList().add(
+                new ExecuteDslScripts(new ExecuteDslScripts.ScriptLocation(Boolean.TRUE.toString(), null, dsl), false, RemovedJobAction.DELETE));
+        // When
+        QueueTaskFuture<FreeStyleBuild> scheduleBuild2 = seedJob.scheduleBuild2(0);
+        // Then (unstable b/c we aren't including the CopyArtifacts dependency)
+        assertBuildStatus(Result.UNSTABLE, scheduleBuild2.get());
+
+        TopLevelItem item = jenkins.getItem("copy-artifacts-test");
+        File config = new File(item.getRootDir(), "promotions/Development/config.xml");
+        String content = Files.toString(config, Charset.forName("UTF-8"));
+        System.out.println("CONTENT: " + content);
+        assert content.contains("<selector class=\"hudson.plugins.copyartifact.SpecificBuildSelector\">");
+    }
+
 }

--- a/src/test/resources/copyartifacts-example-dsl.groovy
+++ b/src/test/resources/copyartifacts-example-dsl.groovy
@@ -1,0 +1,22 @@
+freeStyleJob('copy-artifacts-test') {
+    properties {
+        promotions {
+            promotion {
+                name('Development')
+                conditions {
+                    manual('tester')
+                }
+                actions {
+                    actions {
+                        copyArtifacts('source-job') {
+                            includePatterns('lib/artifact.jar')
+                            buildSelector {
+                                buildNumber('${PROMOTED_NUMBER}')
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-34204

- [x] - Fix the issue
- [x] - add failing test which demonstrates issue with jenkins-job-dsl + copy…-artifacts

@denschu 
I'm not sure what the correct protocol here is (jenkins issue?) but I always prefer a failing test so we'll start there.  

The issue is that jenkins ends up interpreting all configuration as 'latest successful build', regardless of how 'buildSelector' is configured.  It looks like the resulting config.xml of the copyArtifacts step is incorrect.  Specifically, the class of the selector is missing. 

given the following partial dsl:

    copyArtifacts('source-job') {
        buildSelector {
             buildNumber('${PROMOTED_NUMBER}')
        }
    }

something like this is generated at the top level:

    <hudson.plugins.copyartifact.CopyArtifact>
        <selector class="hudson.plugins.copyartifact.SpecificBuildSelector">
            <buildNumber>${PROMOTED_NUMBER}</buildNumber>
        </selector>
    </hudson.plugins.copyartifact.CopyArtifact>

but this is what is generated within promotions/actions:

    <hudson.plugins.copyartifact.CopyArtifact>
        <selector>
            <buildNumber>${PROMOTED_NUMBER}</buildNumber>
        </selector>
    </hudson.plugins.copyartifact.CopyArtifact>


The result is Jenkins will mis-interpret the configuration as 'latest' (I'm guessing b/c it's the default class for the selector).  

I've tracked it down to hudson.plugins.promoted_builds.integrations.jobdsl.PromotionsExtensionPoint#notifyItemCreated(hudson.model.Item, javaposse.jobdsl.plugin.DslEnvironment, boolean), where the conversion to xml is performed - but I don't know enough to venture a guess as to why it works with standard dsl but not when as a promotion step.

If someone can point me in the right direction, I'd be happy to add the fix.