### PR TITLE
Migrate parent POM file and annotate critical methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.565</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>promoted-builds</artifactId>
@@ -15,6 +15,7 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Promoted+Builds+Plugin</url>
 
   <properties>
+    <jenkins.version>1.565</jenkins.version>
     <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
 
   <properties>
     <jenkins.version>1.565</jenkins.version>
-    <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
-    <findbugs.failOnError>true</findbugs.failOnError>
+    <java.level>6</java.level>
   </properties>
 
   <developers>
@@ -158,39 +157,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs-maven-plugin.version}</version>
-        <configuration>
-          <failOnError>${findbugs.failOnError}</failOnError>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <compatibleSinceVersion>2.22</compatibleSinceVersion>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
       <version>1.10</version>
@@ -137,6 +131,30 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
       <version>2.30</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- required to workaround the missing CookieSpecProvider class -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/promoted_builds/FakeParent.java
+++ b/src/main/java/hudson/plugins/promoted_builds/FakeParent.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 
+//TODO: needs polishing
 /**
  * We use this {@link ItemGroup} to create a dangling {@link PromotionProcess}.
  *

--- a/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
+++ b/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
@@ -37,6 +37,7 @@ import hudson.model.JobPropertyDescriptor;
 import hudson.model.listeners.ItemListener;
 import hudson.remoting.Callable;
 import hudson.util.IOUtils;
+import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -47,7 +48,7 @@ import net.sf.json.JSONObject;
  * <p>
  * TODO: a possible performance problem as every time the owner job is reconfigured,
  * all the promotion processes get reloaded from the disk.
- *
+ * </p>
  * @author Kohsuke Kawaguchi
  */
 public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> implements ItemGroup<PromotionProcess> {
@@ -68,6 +69,7 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
     private final Set<String> activeProcessNames = new HashSet<String>();
     /**
      * Programmatic construction.
+     * @param owner owner job
      */
     public JobPropertyImpl(AbstractProject<?,?> owner) throws Descriptor.FormException, IOException {
         this.owner = owner;
@@ -75,6 +77,8 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
     }
     /**
      * Programmatic construction.
+     * @param other Property to be copied
+     * @param owner owner job
      */
     public JobPropertyImpl(JobPropertyImpl other, AbstractProject<?,?> owner) throws Descriptor.FormException, IOException {
         this.owner = owner;
@@ -159,6 +163,9 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
 
     /**
      * Adds a new promotion process of the given name.
+     * @param name Name of the process to be created
+     * @return Created process
+     * @throws IOException Execution error
      */
     public synchronized PromotionProcess addProcess(String name) throws IOException {
         PromotionProcess p = new PromotionProcess(this, name);
@@ -212,6 +219,7 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
 
     /**
      * Builds {@link #activeProcesses}.
+     * @throws IOException Execution error
      */
     private void buildActiveProcess() throws IOException {
         activeProcesses = new ArrayList<PromotionProcess>();
@@ -302,14 +310,18 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
 
     /**
      * Gets {@link AbstractProject} that contains us.
+     * @return Owner project
      */
     public synchronized AbstractProject<?,?> getOwner() {
         return owner;
     }
 
     /**
-     * Finds a config by name.
+     * Finds a {@link PromotionProcess} by name.
+     * @param name Name of the process
+     * @return {@link PromotionProcess} if it can be found.
      */
+    @CheckForNull
     public synchronized PromotionProcess getItem(String name) {
         if (processes == null) {
             return null;

--- a/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
+++ b/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
@@ -98,8 +98,20 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
         // a hack to get the owning AbstractProject.
         // this is needed here so that we can load items
         List<Ancestor> ancs = req.getAncestors();
-        owner = (AbstractProject)ancs.get(ancs.size()-1).getObject();
-
+        final Object ancestor = ancs.get(ancs.size()-1).getObject();
+        if (ancestor instanceof AbstractProject) {
+            owner = (AbstractProject)ancestor;
+        } else if (ancestor == null) {
+            throw new Descriptor.FormException("Cannot retrieve the ancestor item in the request",
+            "owner");
+        } else {
+            throw new Descriptor.FormException("Cannot create Promoted Builds Job Property for " + ancestor.getClass()
+            + ". Currently the plugin supports instances of AbstractProject only."
+            + ". Other job types are not supported, submit a bug to the plugin, which provides the job type"
+            + ". If you use Multi-Branch Project plugin, see https://issues.jenkins-ci.org/browse/JENKINS-32237",
+            "owner");
+        }
+            
         // newer version of Hudson put "promotions". This code makes it work with or without them.
         if(json.has("promotions"))
             json = json.getJSONObject("promotions");

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
@@ -26,6 +26,8 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 @ExportedBean
 public final class PromotedBuildAction implements BuildBadgeAction {
+    
+    //TODO: bug: serialization of builds into the badge
     public final AbstractBuild<?,?> owner;
 
     /**

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -119,8 +120,9 @@ public final class PromotedBuildAction implements BuildBadgeAction {
     
     /**
      * Finds the {@link Status} that has matching {@link Status#name} value.
-     * Or null if not found.
+     * Or {@code null} if not found.
      */
+    @CheckForNull
     public Status getPromotion(String name) {
         for (Status s : statuses)
             if(s.name.equals(name))
@@ -153,8 +155,10 @@ public final class PromotedBuildAction implements BuildBadgeAction {
     }
 
     /**
-     * Get the specified promotion process by name
+     * Get the specified promotion process by name.
+     * @return The discovered process of {@code null} if the promotion cannot be found
      */
+    @CheckForNull
     public PromotionProcess getPromotionProcess(String name) {
         JobPropertyImpl pp = getProject().getProperty(JobPropertyImpl.class);
         if (pp==null)

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
@@ -47,6 +48,12 @@ public class PromotedProjectAction implements ProminentProjectAction, PermalinkP
         return property.getActiveItems();
     }
     
+    /**
+     * Get the promotion process by name.
+     * @param name Name of the process
+     * @return Discovered process or {@code null} if it cannot be found
+     */
+    @CheckForNull
     public PromotionProcess getProcess(String name) {
     	for (PromotionProcess pp : getProcesses() ){
     		if(pp.getName().equals(name))

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
@@ -104,8 +104,8 @@ public class PromotedProjectAction implements ProminentProjectAction, PermalinkP
     /**
      * returns the summary of the latest promotions for a promotion process.
      * 
-     * @param promotionProcessName
-     * @return
+     * @param promotionProcess Name of the promotion process
+     * @return List of latest promotions
      */
     public List<Promotion> getPromotionsSummary(PromotionProcess promotionProcess){
     	List<Promotion> promotionList = this.getPromotions(promotionProcess);

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionCondition.java
@@ -10,6 +10,7 @@ import hudson.plugins.promoted_builds.util.JenkinsHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 
 /**
@@ -29,6 +30,7 @@ public abstract class PromotionCondition implements ExtensionPoint, Describable<
      *      Null if otherwise, meaning it shouldn't be promoted.
      * @deprecated
      */
+    @CheckForNull
     public PromotionBadge isMet(AbstractBuild<?,?> build) {
         return null;
     }

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -442,7 +442,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         return super.scheduleBuild();
     }
 
-    public boolean scheduleBuild(AbstractBuild<?,?> build) {
+    public boolean scheduleBuild(@Nonnull AbstractBuild<?,?> build) {
         return scheduleBuild(build,new UserCause());
     }
 
@@ -454,7 +454,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      *      Use {@link #scheduleBuild2(AbstractBuild, Cause)}
      */
     @Deprecated
-    public boolean scheduleBuild(AbstractBuild<?,?> build, Cause cause) {
+    public boolean scheduleBuild(@Nonnull AbstractBuild<?,?> build, @Nonnull Cause cause) {
         return scheduleBuild2(build,cause)!=null;
     }
 
@@ -466,7 +466,8 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @return Future result or {@code null} if the promotion cannot be scheduled
      */
     @CheckForNull
-    public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause, List<ParameterValue> params) {
+    public Future<Promotion> scheduleBuild2(@Nonnull AbstractBuild<?,?> build, 
+            Cause cause, @CheckForNull List<ParameterValue> params) {
 
         List<Action> actions = new ArrayList<Action>();
        	Promotion.buildParametersAction(actions, build, params);
@@ -482,11 +483,11 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         throw HttpResponses.error(404, "Promotion processes may not be built directly");
     }
 
-    public Future<Promotion> scheduleBuild2(AbstractBuild<?,?> build, Cause cause) {
+    public Future<Promotion> scheduleBuild2(@Nonnull AbstractBuild<?,?> build, @Nonnull Cause cause) {
         return scheduleBuild2(build, cause, null);
     }
 
-    public boolean isInQueue(AbstractBuild<?,?> build) {
+    public boolean isInQueue(@Nonnull AbstractBuild<?,?> build) {
         for (Item item : JenkinsHelper.getInstance().getQueue().getItems(this))
             if (item.getAction(PromotionTargetAction.class).resolve(this)==build)
                 return true;

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionTargetAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionTargetAction.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.InvisibleAction;
 import hudson.plugins.promoted_builds.util.JenkinsHelper;
+import javax.annotation.CheckForNull;
 
 /**
  * Remembers what build it's promoting. Attached to {@link Promotion}.
@@ -19,12 +20,14 @@ public class PromotionTargetAction extends InvisibleAction {
         number = build.getNumber();
     }
 
+    @CheckForNull
     public AbstractBuild<?,?> resolve() {
         AbstractProject<?,?> j = JenkinsHelper.getInstance().getItemByFullName(jobName, AbstractProject.class);
         if (j==null)    return null;
         return j.getBuildByNumber(number);
     }
 
+    @CheckForNull
     public AbstractBuild<?,?> resolve(PromotionProcess parent) {
         AbstractBuild<?,?> build = this.resolve();
         if (build !=null){

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionTrigger.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionTrigger.java
@@ -66,6 +66,9 @@ public class PromotionTrigger extends Trigger<AbstractProject> {
 
         /**
          * Checks the job name.
+         * @param project Current project
+         * @param value Value to be validated
+         * @return Validation result
          */
         public FormValidation doCheckJobName(@AncestorInPath Item project, @QueryParameter String value ) {
             if (!project.hasPermission(Item.CONFIGURE) && project.hasPermission(Item.EXTENDED_READ)) {
@@ -101,6 +104,9 @@ public class PromotionTrigger extends Trigger<AbstractProject> {
 
         /**
          * Fills in the available promotion processes.
+         * @param defaultJob Base job
+         * @param jobName Current name of the job specified in the form
+         * @return List of possible project names. May be empty
          */
         public ListBoxModel doFillProcessItems(@AncestorInPath Item defaultJob, @QueryParameter("jobName") String jobName) {
             if (!defaultJob.hasPermission(Item.CONFIGURE) && defaultJob.hasPermission(Item.EXTENDED_READ)) {

--- a/src/main/java/hudson/plugins/promoted_builds/Status.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Status.java
@@ -26,6 +26,8 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -81,7 +83,9 @@ public final class Status {
 
     /**
      * Gets the parent {@link Status} that owns this object.
+     * @return Promoted build action if it exists in {@link #getTarget()} result.
      */
+    @CheckForNull
     public PromotedBuildAction getParent() {
     	if (parent==null){
     		parent=getTarget().getAction(PromotedBuildAction.class);
@@ -91,8 +95,10 @@ public final class Status {
 
     /**
      * Gets the {@link PromotionProcess} that this object deals with.
+     * @return Gets the promotion process for the status.
      */
     @Exported
+    @CheckForNull
     public PromotionProcess getProcess() {
         assert parent != null : name;
         AbstractProject<?,?> project = parent.getProject();
@@ -104,7 +110,10 @@ public final class Status {
 
     /**
      * Gets the icon that should represent this promotion (that is potentially attempted but failed.)
+     * @param size size of the icon, will be used in the icon path
+     * @return Path to the icon in resources
      */
+    @Nonnull
     public String getIcon(String size) {
         String baseName;
 
@@ -122,8 +131,10 @@ public final class Status {
         return Jenkins.RESOURCE_PATH+"/plugin/promoted-builds/icons/"+size+"/"+ baseName +".png";
     }
 
+    //TODO: what is the Null status?
     /**
      * Gets the build that was qualified for a promotion.
+     * @return Build reference
      */
     public AbstractBuild<?,?> getTarget() {
         return getParent().owner;
@@ -155,7 +166,9 @@ public final class Status {
     }
 
     /**
-     * Gets the string that says how long did it toook for this build to be promoted.
+     * Gets the string that says how long did it took for this build to be promoted.
+     * @param owner Build
+     * @return Time span string formatted by {@link Util#getTimeSpanString(long)}
      */
     public String getDelayString(AbstractBuild<?,?> owner) {
         long duration = timestamp.getTimeInMillis() - owner.getTimestamp().getTimeInMillis() - owner.getDuration();
@@ -169,10 +182,12 @@ public final class Status {
     /**
      * Returns the {@link Promotion} object that represents the successful promotion.
      *
+     * @param jp Job property
      * @return
-     *      null if the promotion has never been successful, or if it was but
+     *      {@code null} if the promotion has never been successful, or if it was but
      *      the record is already lost.
      */
+    @CheckForNull
     public Promotion getSuccessfulPromotion(JobPropertyImpl jp) {
         if(promotion>=0) {
             PromotionProcess p = jp.getItem(name);
@@ -184,21 +199,25 @@ public final class Status {
 
     /**
      * Returns true if the promotion was successfully completed.
+     * @return {@code true} if the there were successful promotions. 
      */
     public boolean isPromotionSuccessful() {
         return promotion>=0;
     }
 
     /**
-     * Returns true if at least one {@link Promotion} activity is attempted.
-     * False if none is executed yet (this includes the case where it's in the queue.)
+     * Checks promotion attempts. 
+     * @return 
+     *  {@code true} if at least one {@link Promotion} activity is attempted.
+     *  {@code false} if none is executed yet (this includes the case where it's in the queue.
      */
     public boolean isPromotionAttempted() {
         return !promotionAttempts.isEmpty();
     }
 
     /**
-     * Returns true if the promotion for this is pending in the queue,
+     * Check if the build is in queue.
+     * @return {@code true} if the promotion for this is pending in the queue,
      * waiting to be executed.
      */
     public boolean isInQueue() {
@@ -208,6 +227,7 @@ public final class Status {
 
     /**
      * Gets the badges indicating how did a build qualify for a promotion.
+     * @return List of promotion badges
      */
     @Exported
     public List<PromotionBadge> getBadges() {
@@ -216,6 +236,7 @@ public final class Status {
 
     /**
      * Called when a new promotion attempts for this build starts.
+     * @param p Promotion
      */
     /*package*/ void addPromotionAttempt(Promotion p) {
         promotionAttempts.add(p.getNumber());
@@ -223,6 +244,7 @@ public final class Status {
 
     /**
      * Called when a promotion succeeds.
+     * @param p Promotion
      */
     /*package*/ void onSuccessfulPromotion(Promotion p) {
         promotion = p.getNumber();
@@ -234,7 +256,9 @@ public final class Status {
 
     /**
      * Gets the last successful {@link Promotion}.
+     * @return Last successful promotion or {@code null} if there is no successful ones.
      */
+    @CheckForNull
     public Promotion getLastSuccessful() {
         PromotionProcess p = getProcess();
         for( Integer n : Iterators.reverse(promotionAttempts) ) {
@@ -246,8 +270,10 @@ public final class Status {
     }
 
     /**
-     * Gets the last successful {@link Promotion}.
+     * Gets the last failed {@link Promotion}.
+     * @return Last failed promotion or {@code null} if there is no failed ones.
      */
+    @CheckForNull
     public Promotion getLastFailed() {
         PromotionProcess p = getProcess();
         for( Integer n : Iterators.reverse(promotionAttempts) ) {
@@ -258,6 +284,11 @@ public final class Status {
         return null;
     }
 
+    /**
+     * Gets the last {@link Promotion}.
+     * @return Last promotion or {@code null} if there is no promotions.
+     */
+    @CheckForNull
     public Promotion getLast() {
         PromotionProcess p = getProcess();
         for( Integer n : Iterators.reverse(promotionAttempts) ) {
@@ -277,6 +308,7 @@ public final class Status {
 
     /**
      * Gets all the promotion builds.
+     * @return List of promotions
      */
     @Exported
     public List<Promotion> getPromotionBuilds() {
@@ -299,6 +331,7 @@ public final class Status {
      * @param number build number
      * @return promotion build
      */
+    @CheckForNull
     public Promotion getPromotionBuild(int number) {
         PromotionProcess p = getProcess();
         return p.getBuildByNumber(number);
@@ -310,6 +343,10 @@ public final class Status {
     }
     /**
      * Schedules a new build.
+     * @param req Request
+     * @param rsp Response
+     * @throws IOException Functional error
+     * @throws ServletException Request handling error
      */
     public void doBuild(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -116,11 +116,12 @@ public class DownstreamPassCondition extends PromotionCondition {
     }
 
     /**
-     *  @deprecated use {@link #getJobList(hudson.model.ItemGroup, hudson.model.AbstractProject, hudson.EnvVars)} 
+     * @deprecated use {@link #getJobList(hudson.model.ItemGroup, hudson.EnvVars)} 
      * List of downstream jobs that we need to monitor.
      *
      * @return never null.
      */
+    @Deprecated
     public List<AbstractProject<?,?>> getJobList(ItemGroup context){
     	return getJobList(context, null);
     }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -283,7 +283,7 @@ public class DownstreamPassCondition extends PromotionCondition {
         }
 
         /**
-         * Called whenever some {@link JobPropertyImpl} changes to update {@link #DOWNSTREAM_JOBS}.
+         * Called whenever some {@link JobPropertyImpl} changes to update downstream jobs.
          * @deprecated Caches are not being used anymore
          */
         @Deprecated

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import javax.servlet.ServletException;
@@ -80,6 +81,7 @@ public class ManualCondition extends PromotionCondition {
     /**
      * Gets the {@link ParameterDefinition} of the given name, if any.
      */
+    @CheckForNull
     public ParameterDefinition getParameterDefinition(String name) {
         if (parameterDefinitions == null) {
             return null;
@@ -164,6 +166,8 @@ public class ManualCondition extends PromotionCondition {
         }
         return false;
     }
+    
+    @CheckForNull
     public Future<Promotion> approve(AbstractBuild<?,?> build, PromotionProcess promotionProcess, List<ParameterValue> paramValues) throws IOException{
         if (canApprove(promotionProcess, build)) {            
             // add approval to build

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition.java
@@ -19,7 +19,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * {@link PromotionCondition} that promotes a build as soon as it's done if a
  * given parameter has the specified value.
  *
- * @author Grant Limberg <glimberg@gmail.com>
+ * @author Grant Limberg (glimberg at gmail.com)
  */
 public class ParameterizedSelfPromotionCondition extends SelfPromotionCondition {
     private final String parameterName;

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
@@ -14,6 +14,7 @@ import com.thoughtworks.xstream.mapper.Mapper;
 import groovy.util.Node;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
+import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 
 /**
@@ -99,6 +100,7 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
         writer.endNode();
     }
 
+    @CheckForNull
     private String obtainClassOwnership() {
         if (this.classOwnership != null) {
             return this.classOwnership;

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsContext.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsContext.java
@@ -24,29 +24,32 @@ public class PromotionsContext implements Context {
         this.dslEnvironment = dslEnvironment;
     }
 
+    //TODO: What does this Javadoc mean? Just marked as pre
     /**
+     * See the examples below.
+     * 
      * PromotionNodes:
-     * 1. <string>dev</string>
-     * 2. <string>test</string>
+     * <pre>
+     * 1. &lt;string&gt;dev&lt;/string&gt;
+     * 2. &lt;string&gt;test&lt;/string&gt;
      * 
      * AND
      * 
-     * Sub PromotionNode for every promotion
-     * 1. <project>
-     * <name>dev</name>
+     * Sub PromotionNode for every promotion:
+     * 1. &lt;project&gt;
+     * &lt;name&gt;dev&lt;/name&gt;
      * .
      * .
      * .
-     * </project>
-     * 2. <project>
-     * <name>test</name>
+     * &lt;/project&gt;
+     * 2. &lt;project&gt;
+     * &lt;name&gt;test&lt;/name&gt;
      * .
      * .
      * .
-     * </project>
-     * 
-     * @param promotionClosure
-     * @return
+     * &lt;/project&gt;
+     * </pre>
+     * @param promotionClosure Input closure
      */
     public void promotion(Closure<?> promotionClosure) {
         PromotionContext promotionContext = new PromotionContext(dslEnvironment);

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
@@ -27,8 +27,9 @@ import javaposse.jobdsl.plugin.DslEnvironment;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
 
 /**
- * The Job DSL Extension Point for the Promotions. See also {@linktourl https://github.com/jenkinsci/job-dsl-plugin/wiki/Extending-the-DSL}
- *
+ * The Job DSL Extension Point for the Promotions. 
+ * See also <a href="https://github.com/jenkinsci/job-dsl-plugin/wiki/Extending-the-DSL">Extending the DSL</a>
+ * 
  * @author Dennis Schulte
  */
 @Extension

--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
@@ -67,6 +67,7 @@ import org.kohsuke.stapler.export.Exported;
  * Starting from TODO, the field also supports folders and the relative addressing (JENKINS-25011). 
  * See {@link ItemPathResolver#getByPath(java.lang.String, hudson.model.Item, java.lang.Class)} 
  * for the documentation.
+ * </p>
  * @author Pete Hayes
  */
 public class PromotedBuildParameterDefinition extends SimpleParameterDefinition {
@@ -139,7 +140,7 @@ public class PromotedBuildParameterDefinition extends SimpleParameterDefinition 
      * @deprecated This method retrieves the base item for relative addressing from 
      * the {@link StaplerRequest}. The relative addressing may be malfunctional if
      * you use this method outside {@link StaplerRequest}s. 
-     * Use {@link #getBuilds(hudson.model.Item)} instead
+     * Use {@link #getRuns(hudson.model.Item)} instead
      */
     @Nonnull
     @Deprecated

--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildRebuildParameterProvider.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildRebuildParameterProvider.java
@@ -36,9 +36,9 @@ public class PromotedBuildRebuildParameterProvider extends RebuildParameterProvi
 
     /**
      * Provide a view for specified {@link PromotedBuildParameterValue}.
-     * <p/>
+     * <p>
      * Return null if cannot handle specified {@link PromotedBuildParameterValue}.
-     *
+     * </p>
      * @param value a value to be shown in a rebuild page.
      * @return page for the parameter value. null for parameter values cannot be handled.
      */

--- a/src/main/java/hudson/plugins/promoted_builds/util/ItemPathResolver.java
+++ b/src/main/java/hudson/plugins/promoted_builds/util/ItemPathResolver.java
@@ -83,6 +83,7 @@ public class ItemPathResolver {
      * The implementation retains the original behavior in {@link PromotedBuildParameterDefinition}, 
      * but this method also provides a support of multi-level addressing including special markups
      * for the relative addressing.
+     * </p>
      * Effectively, the resolution order is following:
      * <ul>
      *   <li><b>Optional</b> Legacy behavior, which can be enabled by {@link #ENABLE_LEGACY_RESOLUTION_AGAINST_ROOT}. 
@@ -95,9 +96,8 @@ public class ItemPathResolver {
      * For the relative and absolute addressing the engine supports &quot;.&quot; and
      * &quot;..&quot; markers within the path.
      * The first one points to the current element, the second one - to the upper element. 
-     * If the search cannot get a new top element (e.g. reached the root), the method returns <code>null</code>.
+     * If the search cannot get a new top element (e.g. reached the root), the method returns {@code null}.
      * 
-     * </p>
      * @param <T> Type of the {@link Item} to be retrieved
      * @param path Path string to the item. 
      * @param baseItem Base {@link Item} for the relative addressing. If null,

--- a/src/main/resources/hudson/plugins/promoted_builds/JobPropertyImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/JobPropertyImpl/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="promotions" title="Promote builds when..." checked="${!empty(instance.activeItems)}" help="/plugin/promoted-builds/help.html">
     <f:block><div style="padding-left:2em">

--- a/src/main/resources/hudson/plugins/promoted_builds/ManualPromotionBadge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/ManualPromotionBadge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
     Manually qualified for a promotion

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.hasPromotion()}">
     <j:forEach var="status" items="${it.getPromotions()}">

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
 
   <l:layout title="${%Promotions} : ${it.project.displayName} ${it.owner.displayName}" xmlns:local="local">

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
 
   <l:layout title="Promotions : ${it.owner.displayName}">

--- a/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
@@ -1,6 +1,7 @@
 <!--
   Displays the console output
 -->
+<?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.parent.displayName} #${it.number} Console" norefresh="true">
     <l:header />

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <fieldset style="margin-bottom:1em">
     <legend>${%Promotion process}</legend>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionTrigger/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Job Name}">
     <f:textbox field="jobName" />

--- a/src/main/resources/hudson/plugins/promoted_builds/PublisherImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PublisherImpl/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:nested>
     <f:repeatable var="s" items="${instance.criteria}" noAddButton="true" minimum="1" name="criteria">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/Badge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/Badge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:pane title="${%Downstream builds succeeded}" width="100">
     <j:forEach var="b" items="${it.builds}">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Job names">
     <f:textbox field="jobs" autoCompleteDelimChar=","/>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:pane title="${%Downstream builds}" width="100">
     <j:forEach var="job" items="${it.jobList}">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/GroovyCondition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:property field="script"/>
   <f:advanced>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/Badge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/Badge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:pane title="${%Manually Approved}" width="100"><tr><td>
     <f:form method="post" action="${h.encode(p.name)}/build" name="build">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/config.jelly
@@ -1,4 +1,5 @@
 <!-- nothing to configure -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Approvers">
     <f:textbox name="promotion.manual.users" value="${instance.users}" />

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ManualCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:pane title="${%Manual Approval}" width="100"><tr><td>
     <f:form method="post" action="promotionProcess/${h.encode(p.name)}/promotionCondition/hudson.plugins.promoted_builds.conditions.ManualCondition/approve" name="approve">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionBadge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   ${%Automatically promoted immediately after the build because parameter was matched}
 </div>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry>
     <f:checkbox name="promotion.self.evenIfUnstable" checked="${instance.evenIfUnstable}"/>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/ParameterizedSelfPromotionCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionBadge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionBadge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   ${%Automatically promoted immediately after the build}
 </div>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry>
     <f:checkbox name="promotion.self.evenIfUnstable" checked="${instance.evenIfUnstable}"/>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/SelfPromotionCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   ${%Build still in progress or failed - not automatically promoted}
 </div>

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/Badge/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/Badge/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:pane title="${%Upstream promotions succeeded}" width="100">
     <j:forEach var="p" items="${it.promotions}">

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="Promotion names">
     <f:textbox name="promotion.upstream.promotions" value="${instance.requiredPromotionNames}" />

--- a/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:pane title="${%Upstream promotions}" width="100">
     <j:forEach var="p" items="${it.requiredPromotionNamesAsSet}">

--- a/src/main/resources/hudson/plugins/promoted_builds/tokenmacro/help.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/tokenmacro/help.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <dt>$${PROMOTION_ENV,var="VARIABLENAME"}</dt>
   <dd>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin implements a "promoted build" feature where a build of one job can be marked as "promoted"
   when it passes certain criteria.

--- a/src/test/java/hudson/plugins/promoted_builds/ConfigurationDoCheckTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/ConfigurationDoCheckTest.java
@@ -27,7 +27,7 @@ public class ConfigurationDoCheckTest extends HudsonTestCase {
         proc.icon = "star-blue";
 
         WebClient client = new WebClient();
-        client.setThrowExceptionOnFailingStatusCode(false);
+        client.getOptions().setThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = submit(client.getPage(p, "configure").getFormByName("config"));
         assertTrue(page.asText().contains("No name is specified"));
 
@@ -48,7 +48,7 @@ public class ConfigurationDoCheckTest extends HudsonTestCase {
         proc.icon = "star-blue";
 
         WebClient client = new WebClient();
-        client.setThrowExceptionOnFailingStatusCode(false);
+        client.getOptions().setThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = submit(client.getPage(p, "configure").getFormByName("config"));
         assertTrue(page.asText().contains("unsafe character"));
 

--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildActionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildActionTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.promoted_builds;
 
 import com.gargoylesoftware.htmlunit.html.HtmlImage;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.Cause.UserCause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -30,7 +31,13 @@ public class PromotedBuildActionTest extends HudsonTestCase {
         assertTrue(base.getActiveItems().isEmpty());
 
         // make sure that the page renders OK without any error
-        for (HtmlImage img : createWebClient().getPage(p).<HtmlImage>selectNodes("//IMG")) {
+        HtmlPage page = createWebClient().getPage(p);
+        List<?> candidates = page.getByXPath("//IMG");
+        for (Object candidate : candidates) {
+            if (!(candidate instanceof HtmlImage)) {
+                continue;
+            } 
+            HtmlImage img = (HtmlImage)candidate;
             try {
                 img.getHeight();
             } catch (IOException e) {

--- a/src/test/java/hudson/plugins/promoted_builds/RemoteApiTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/RemoteApiTest.java
@@ -62,6 +62,7 @@ public class RemoteApiTest {
         assertTrue(xml, xml.contains("SelfPromotionCondition"));
         assertTrue(xml, xml.contains("<evenIfUnstable>true</evenIfUnstable>"));
         WebRequest req = new WebRequest(wc.createCrumbedUrl("job/p/promotion/process/promo/config.xml"), HttpMethod.POST);
+        req.setEncodingType(null);
         req.setRequestBody(xml.replace("<evenIfUnstable>true</evenIfUnstable>", "<evenIfUnstable>false</evenIfUnstable>"));
         assertTrue(proc.conditions.get(SelfPromotionCondition.class).isEvenIfUnstable());
         wc.getPage(req);
@@ -112,6 +113,7 @@ public class RemoteApiTest {
         assertEquals(0, promotion.getActiveItems().size());
         JenkinsRule.WebClient wc = r.createWebClient();
         WebRequest req = new WebRequest(new URL(wc.createCrumbedUrl("job/p/promotion/createProcess") + "&name=promo"), HttpMethod.POST);
+        req.setEncodingType(null);
         req.setRequestBody("<hudson.plugins.promoted__builds.PromotionProcess><conditions><hudson.plugins.promoted__builds.conditions.SelfPromotionCondition><evenIfUnstable>true</evenIfUnstable></hudson.plugins.promoted__builds.conditions.SelfPromotionCondition></conditions></hudson.plugins.promoted__builds.PromotionProcess>");
         wc.getPage(req);
         assertEquals(1, promotion.getItems().size());

--- a/src/test/java/hudson/plugins/promoted_builds/RemoteApiTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/RemoteApiTest.java
@@ -25,7 +25,7 @@
 package hudson.plugins.promoted_builds;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
-import com.gargoylesoftware.htmlunit.WebRequestSettings;
+import com.gargoylesoftware.htmlunit.WebRequest;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
@@ -61,7 +61,7 @@ public class RemoteApiTest {
         String xml = wc.goToXml("job/p/promotion/process/promo/config.xml").getContent();
         assertTrue(xml, xml.contains("SelfPromotionCondition"));
         assertTrue(xml, xml.contains("<evenIfUnstable>true</evenIfUnstable>"));
-        WebRequestSettings req = new WebRequestSettings(wc.createCrumbedUrl("job/p/promotion/process/promo/config.xml"), HttpMethod.POST);
+        WebRequest req = new WebRequest(wc.createCrumbedUrl("job/p/promotion/process/promo/config.xml"), HttpMethod.POST);
         req.setRequestBody(xml.replace("<evenIfUnstable>true</evenIfUnstable>", "<evenIfUnstable>false</evenIfUnstable>"));
         assertTrue(proc.conditions.get(SelfPromotionCondition.class).isEvenIfUnstable());
         wc.getPage(req);
@@ -99,7 +99,7 @@ public class RemoteApiTest {
         assertEquals(1, promotion.getItems().size());
         assertEquals(1, promotion.getActiveItems().size());
         JenkinsRule.WebClient wc = r.createWebClient();
-        wc.getPage(wc.addCrumb(new WebRequestSettings(new URL(r.getURL(), "job/p/promotion/process/promo/doDelete"), HttpMethod.POST)));
+        wc.getPage(wc.addCrumb(new WebRequest(new URL(r.getURL(), "job/p/promotion/process/promo/doDelete"), HttpMethod.POST)));
         assertEquals(0, promotion.getItems().size());
         assertEquals(0, promotion.getActiveItems().size());
     }
@@ -111,7 +111,7 @@ public class RemoteApiTest {
         assertEquals(0, promotion.getItems().size());
         assertEquals(0, promotion.getActiveItems().size());
         JenkinsRule.WebClient wc = r.createWebClient();
-        WebRequestSettings req = new WebRequestSettings(new URL(wc.createCrumbedUrl("job/p/promotion/createProcess") + "&name=promo"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.createCrumbedUrl("job/p/promotion/createProcess") + "&name=promo"), HttpMethod.POST);
         req.setRequestBody("<hudson.plugins.promoted__builds.PromotionProcess><conditions><hudson.plugins.promoted__builds.conditions.SelfPromotionCondition><evenIfUnstable>true</evenIfUnstable></hudson.plugins.promoted__builds.conditions.SelfPromotionCondition></conditions></hudson.plugins.promoted__builds.PromotionProcess>");
         wc.getPage(req);
         assertEquals(1, promotion.getItems().size());


### PR DESCRIPTION
- [x] Migrate parent pom to 2.x
- [x] Make the tests compilable
- [x] Fix Javadoc critical issues
- [x] Annotate methods, which may really return null
- [x] Fix the tests to work with new HtmlUnit
- [x] Fix critical issues discovered by FindBugs (NPEs, etc.)

Issues being addressed:
* https://issues.jenkins-ci.org/browse/JENKINS-34187
* https://issues.jenkins-ci.org/browse/JENKINS-32237
* https://issues.jenkins-ci.org/browse/JENKINS-19940
* https://issues.jenkins-ci.org/browse/JENKINS-22632

Disclaimer: I know about javax.annotation. They already exist in the plugin, hence I'll perform a bulk change later.