### PR TITLE
Changed to use WorkspaceList.allocate instead of acquire.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -309,7 +309,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
             if (workspace == null) {
                 throw new IOException("Cannot retrieve workspace for " + item + " on the node " + n);
             }
-            return wsl.acquire(workspace, true);
+            return wsl.allocate(workspace, promotionRun);
         }
 
         protected Result doRun(BuildListener listener) throws Exception {


### PR DESCRIPTION
Acquiring a quick lock causes parallelised builds to back up waiting for
the workspace to become available.  This is because WorkspaceList.allocate
will give executing jobs the first workspace as the given lock is a quick
lock.  Then builds will wait in WorkspaceList.acquire all trying to get
the same workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/promoted-builds-plugin/90)
<!-- Reviewable:end -->
