### PR TITLE
Make PromotionsExtensionPoint an optional extension

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
@@ -32,7 +32,7 @@ import javaposse.jobdsl.plugin.DslExtensionMethod;
  * 
  * @author Dennis Schulte
  */
-@Extension
+@Extension(optional=true)
 public class PromotionsExtensionPoint extends ContextExtensionPoint {
 
     private static final Logger LOGGER = Logger.getLogger(PromotionsExtensionPoint.class.getName());


### PR DESCRIPTION
As per [this comment](https://github.com/jenkinsci/promoted-builds-plugin/commit/327d0233255d0a2c2806c3337daac97e8580905c#commitcomment-17432529). 2.26 throws big scary exceptions.

@reviewbybees esp. @daniel-beck, @oleg-nenashev