### PR TITLE
[JENKINS-34826] - Prevent failures when using parameters from the promoted build

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -492,7 +492,6 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
             unfilteredParameters = params;
         }
 
-        @Exported(visibility=2)
         @Override
         public List<ParameterValue> getParameters() {
             return Collections.unmodifiableList(filter(unfilteredParameters));
@@ -513,7 +512,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
 
             List<ParameterValue> params = new ArrayList<ParameterValue>();
 
-            //Add the target build parameters first, if the same parameter is not being provided bu the promotion build
+            //Add the target build parameters first, if the same parameter is not being provided by the promotion build
             List<ParametersAction> parameters = buildToBePromoted.getActions(ParametersAction.class);
             for (ParametersAction paramAction : parameters) {
                 for (ParameterValue pvalue : paramAction.getParameters()) {

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -484,18 +484,18 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     @Restricted(NoExternalUse.class)
     public static class PromotionParametersAction extends ParametersAction {
         
-        private List<ParameterValue> parameters;
+        private List<ParameterValue> unfilteredParameters;
         
         private PromotionParametersAction(List<ParameterValue> params) {
             // Pass the parameters upstairs
             super(params);   
-            parameters = params;
+            unfilteredParameters = params;
         }
 
         @Exported(visibility=2)
         @Override
         public List<ParameterValue> getParameters() {
-            return Collections.unmodifiableList(filter(parameters));
+            return Collections.unmodifiableList(filter(unfilteredParameters));
         }
         
         private List<ParameterValue> filter(List<ParameterValue> params) {

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -49,6 +49,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Records a promotion process.
@@ -461,32 +463,71 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
      * @param actions
      * @param build
      * @param promotionParams
+     * @deprecated Use {@link PromotionParametersAction} with constructor instead.
      */
-	public static void buildParametersAction(@Nonnull List<Action> actions, 
-                @Nonnull AbstractBuild<?, ?> build,
-                @CheckForNull List<ParameterValue> promotionParams) {
-        if (promotionParams == null) {
-            promotionParams = new ArrayList<ParameterValue>();
-        }
-
-		List<ParameterValue> params=new ArrayList<ParameterValue>();
-		
-		//Add the target build parameters first, if the same parameter is not being provided bu the promotion build
-        List<ParametersAction> parameters = build.getActions(ParametersAction.class);
-        for(ParametersAction paramAction:parameters){
-        	for (ParameterValue pvalue:paramAction.getParameters()){
-        		if (!promotionParams.contains(pvalue)){
-        			params.add(pvalue);
-        		}
-        	}
-        }
-        
-        //Add all the promotion build parameters
-        params.addAll(promotionParams);
-        
+    @Deprecated
+    public static void buildParametersAction(@Nonnull List<Action> actions,
+            @Nonnull AbstractBuild<?, ?> build,
+            @CheckForNull List<ParameterValue> promotionParams) {
         // Create list of actions to pass to scheduled build
-        actions.add(new ParametersAction(params));
-	}
+        actions.add(PromotionParametersAction.buildFor(build, promotionParams));
+    }
 
     private static final Logger LOGGER = Logger.getLogger(Promotion.class.getName());
+    
+    /**
+     * Action, which stores promotion parameters.
+     * This class allows defining custom parameters filtering logic, which is
+     * important for versions after the SECURITY-170 fix.
+     * @since TODO
+     */
+    @Restricted(NoExternalUse.class)
+    public static class PromotionParametersAction extends ParametersAction {
+        
+        private List<ParameterValue> parameters;
+        
+        private PromotionParametersAction(List<ParameterValue> params) {
+            // Pass the parameters upstairs
+            super(params);   
+            parameters = params;
+        }
+
+        @Exported(visibility=2)
+        @Override
+        public List<ParameterValue> getParameters() {
+            return Collections.unmodifiableList(filter(parameters));
+        }
+        
+        private List<ParameterValue> filter(List<ParameterValue> params) {
+            // buildToBePromoted::getParameters() invokes the secured method, hence all
+            // parameters from the promoted build are safe.
+            return params;
+        }
+        
+        public static PromotionParametersAction buildFor(
+                @Nonnull AbstractBuild<?, ?> buildToBePromoted,
+                @CheckForNull List<ParameterValue> promotionParams) {
+            if (promotionParams == null) {
+                promotionParams = new ArrayList<ParameterValue>();
+            }
+
+            List<ParameterValue> params = new ArrayList<ParameterValue>();
+
+            //Add the target build parameters first, if the same parameter is not being provided bu the promotion build
+            List<ParametersAction> parameters = buildToBePromoted.getActions(ParametersAction.class);
+            for (ParametersAction paramAction : parameters) {
+                for (ParameterValue pvalue : paramAction.getParameters()) {
+                    if (!promotionParams.contains(pvalue)) {
+                        params.add(pvalue);
+                    }
+                }
+            }
+
+            //Add all the promotion build parameters
+            params.addAll(promotionParams);
+
+            // Create list of actions to pass to scheduled build
+            return new PromotionParametersAction(params);
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -521,7 +521,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
     public Future<Promotion> scheduleBuild2(@Nonnull AbstractBuild<?,?> build, 
             Cause cause, @CheckForNull List<ParameterValue> params) {
         List<Action> actions = new ArrayList<Action>();
-        Promotion.buildParametersAction(actions, build, params);
+        actions.add(Promotion.PromotionParametersAction.buildFor(build, params));
         actions.add(new PromotionTargetAction(build));
 
         // remember what build we are promoting

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
@@ -135,6 +135,7 @@ public class SelfPromotionTest extends HudsonTestCase {
     }
 
     @Bug(22679)
+    // @Bug(34826) // Can be reproduced in Jenkins 2.3 +
     public void testPromotionEnvironmentShouldIncludeTargetParameters() throws Exception {
         String paramName = "param";
 


### PR DESCRIPTION
Insertion of ParametersDefinition seems to be unsafe according to the job initialization logic and new TCB plugin options (filter by param values), so I've finally implemented a straightforward fix.

https://issues.jenkins-ci.org/browse/JENKINS-34826

@reviewbybees @amuniz 