### PR TITLE
[JENKINS-40552] Remove unnecessary synchronization from method.

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
+++ b/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
@@ -324,7 +324,7 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
      * Gets {@link AbstractProject} that contains us.
      * @return Owner project
      */
-    public synchronized AbstractProject<?,?> getOwner() {
+    public AbstractProject<?,?> getOwner() {
         return owner;
     }
 

--- a/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
+++ b/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
@@ -214,18 +214,20 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
     }
 
     @Override
-    protected synchronized void setOwner(AbstractProject<?,?> owner) {
+    protected void setOwner(AbstractProject<?,?> owner) {
         super.setOwner(owner);
 
         // readResolve is too early because we don't have our parent set yet,
         // so use this as the initialization opportunity.
         // CopyListener is also using setOwner to re-init after copying config from another job.
-        processes = new ArrayList<PromotionProcess>(ItemGroupMixIn.<String,PromotionProcess>loadChildren(
-                this,getRootDir(),ItemGroupMixIn.KEYED_BY_NAME).values());
-        try {
-            buildActiveProcess();
-        } catch (IOException e) {
-            throw new Error(e);
+        synchronized (this) {
+            processes = new ArrayList<PromotionProcess>(ItemGroupMixIn.<String, PromotionProcess>loadChildren(
+                    this, getRootDir(), ItemGroupMixIn.KEYED_BY_NAME).values());
+            try {
+                buildActiveProcess();
+            } catch (IOException e) {
+                throw new Error(e);
+            }
         }
     }
 


### PR DESCRIPTION
It is probably unnecessary to have the `getOwner` method synchronized.

Credit goes to @jglick as the PR was created as part of a comment he made on [the jira](https://issues.jenkins-ci.org/browse/JENKINS-40552?focusedCommentId=280911&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280911).

@reviewbybees