### PR TITLE
[JENKINS-37368] Improve performance in DownstreamPassCondition RunListener

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -269,11 +269,11 @@ public class DownstreamPassCondition extends PromotionCondition {
             SecurityContext previousCtx = ACL.impersonate(ACL.SYSTEM);
             try {
                 EnvVars buildEnvironment = new EnvVars(build.getBuildVariables());
-                for (AbstractProject<?, ?> j : JenkinsHelper.getInstance().getAllItems(AbstractProject.class)) {
+                for (AbstractProject<?,?> j : JenkinsHelper.getInstance().getAllItems(AbstractProject.class)) {
                     boolean warned = false; // used to avoid warning for the same project more than once.
 
                     JobPropertyImpl jp = j.getProperty(JobPropertyImpl.class);
-                    if (jp != null) {
+                    if (jp!=null) {
                         for (PromotionProcess p : jp.getItems()) {
                             boolean considerPromotion = false;
                             for (PromotionCondition cond : p.conditions) {
@@ -288,8 +288,8 @@ public class DownstreamPassCondition extends PromotionCondition {
                             }
                             if (considerPromotion) {
                                 try {
-                                    AbstractBuild<?, ?> u = build.getUpstreamRelationshipBuild(j);
-                                    if (u == null) {
+                                    AbstractBuild<?,?> u = build.getUpstreamRelationshipBuild(j);
+                                    if (u==null) {
                                         // if the fingerprint doesn't tell us, perhaps the cause would tell us?
                                         final Stack<List<Cause>> stack = new Stack<List<Cause>>();
                                         stack.push(build.getCauses());
@@ -298,11 +298,11 @@ public class DownstreamPassCondition extends PromotionCondition {
                                             for (UpstreamCause uc : Util.filter(stack.pop(), UpstreamCause.class)) {
                                                 if (uc.getUpstreamProject().equals(j.getFullName())) {
                                                     u = j.getBuildByNumber(uc.getUpstreamBuild());
-                                                    if (u != null) {
+                                                    if (u!=null) {
                                                         // remember that this build is a pseudo-downstream of the discovered build.
                                                         PseudoDownstreamBuilds pdb = u.getAction(PseudoDownstreamBuilds.class);
-                                                        if (pdb == null)
-                                                            u.addAction(pdb = new PseudoDownstreamBuilds());
+                                                        if (pdb==null)
+                                                            u.addAction(pdb=new PseudoDownstreamBuilds());
                                                         pdb.add(build);
                                                         u.save();
                                                         break;
@@ -314,16 +314,16 @@ public class DownstreamPassCondition extends PromotionCondition {
                                     }
                                     if (u == null) {
                                         // no upstream build. perhaps a configuration problem?
-                                        if (build.getResult() == Result.SUCCESS && !warned) {
-                                            listener.getLogger().println("WARNING: " + j.getFullDisplayName() + " appears to use this job as a promotion criteria, " +
-                                                    "but no fingerprint is recorded. Fingerprint needs to be enabled on both this job and " + j.getFullDisplayName() + ". " +
+                                        if (build.getResult()==Result.SUCCESS && !warned) {
+                                            listener.getLogger().println("WARNING: "+j.getFullDisplayName()+" appears to use this job as a promotion criteria, " +
+                                                    "but no fingerprint is recorded. Fingerprint needs to be enabled on both this job and "+j.getFullDisplayName()+". " +
                                                     "See https://wiki.jenkins-ci.org/display/JENKINS/Fingerprint for more details");
                                             warned = true;
                                         }
                                     }
 
-                                    if (u != null && p.considerPromotion2(u) != null)
-                                        listener.getLogger().println("Promoted " + HyperlinkNote.encodeTo('/' + u.getUrl(), u.getFullDisplayName()));
+                                    if (u!=null && p.considerPromotion2(u)!=null)
+                                        listener.getLogger().println("Promoted " + HyperlinkNote.encodeTo('/'+u.getUrl(), u.getFullDisplayName()));
                                 } catch (IOException e) {
                                     e.printStackTrace(listener.error("Failed to promote a build"));
                                 }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -279,8 +279,8 @@ public class DownstreamPassCondition extends PromotionCondition {
                             for (PromotionCondition cond : p.conditions) {
                                 if (cond instanceof DownstreamPassCondition) {
                                     DownstreamPassCondition dpcond = (DownstreamPassCondition) cond;
-                                    if (j.getACL().hasPermission(previousCtx.getAuthentication(), Item.READ)
-                                            && dpcond.contains(j.getParent(), build.getParent(), buildEnvironment)) {
+                                    if (dpcond.contains(j.getParent(), build.getParent(), buildEnvironment)
+                                            && j.getACL().hasPermission(previousCtx.getAuthentication(), Item.READ)) {
                                         considerPromotion = true;
                                         break;
                                     }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -266,9 +266,9 @@ public class DownstreamPassCondition extends PromotionCondition {
         @Override
         public void onCompleted(AbstractBuild<?,?> build, TaskListener listener) {
             // this is not terribly efficient,
+            EnvVars buildEnvironment = new EnvVars(build.getBuildVariables());
             SecurityContext previousCtx = ACL.impersonate(ACL.SYSTEM);
             try {
-                EnvVars buildEnvironment = new EnvVars(build.getBuildVariables());
                 for (AbstractProject<?,?> j : JenkinsHelper.getInstance().getAllItems(AbstractProject.class)) {
                     boolean warned = false; // used to avoid warning for the same project more than once.
 

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -312,7 +312,7 @@ public class DownstreamPassCondition extends PromotionCondition {
                                             }
                                         }
                                     }
-                                    if (u == null) {
+                                    if (u==null) {
                                         // no upstream build. perhaps a configuration problem?
                                         if (build.getResult()==Result.SUCCESS && !warned) {
                                             listener.getLogger().println("WARNING: "+j.getFullDisplayName()+" appears to use this job as a promotion criteria, " +

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/DownstreamPassConditionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/DownstreamPassConditionTest.java
@@ -24,14 +24,19 @@
 package hudson.plugins.promoted_builds.conditions;
 
 import static org.junit.Assert.*;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.context.SecurityContextHolder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import hudson.model.Actionable;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import hudson.model.User;
 import hudson.plugins.promoted_builds.JobPropertyImpl;
 import hudson.plugins.promoted_builds.PromotedBuildAction;
 import hudson.plugins.promoted_builds.PromotionProcess;
@@ -70,7 +75,45 @@ public final class DownstreamPassConditionTest {
         assertEquals("fingerprint relation", run3.getUpstreamRelationship(job1), -1);
         assertFalse("no promotion process", process.getBuilds().isEmpty());
 
-        final PromotedBuildAction action = run1.getAction(PromotedBuildAction.class);
+        assertPromotedSuccessfully(run1);
+    }
+
+    @Test
+    @Issue("JENKINS-37368")
+    public void shouldResetSecurityContext() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        User user1 = User.get("user1");
+
+        Authentication originalAuth = user1.impersonate();
+        SecurityContextHolder.getContext().setAuthentication(originalAuth);
+
+        final FreeStyleProject job1 = j.createFreeStyleProject("job1");
+        final FreeStyleProject job2 = j.createFreeStyleProject("job2");
+
+        final JobPropertyImpl property = new JobPropertyImpl(job1);
+        job1.addProperty(property);
+
+        final PromotionProcess process = property.addProcess("promotion");
+        process.conditions.add(new DownstreamPassCondition(job2.getFullName()));
+
+        job1.getPublishersList().add(new BuildTrigger(job2.getFullName(), Result.SUCCESS));
+        j.jenkins.rebuildDependencyGraph();
+
+        final FreeStyleBuild run1 = j.buildAndAssertSuccess(job1);
+        j.waitUntilNoActivity();
+        j.assertBuildStatusSuccess(job2.getLastBuild());
+        j.waitUntilNoActivity();
+
+        assertPromotedSuccessfully(run1);
+
+        assertEquals("security context not reset", SecurityContextHolder.getContext().getAuthentication(), originalAuth);
+    }
+
+    /**
+     * Asserts that a build was promoted successfully.
+     */
+    private void assertPromotedSuccessfully(Actionable build) {
+        final PromotedBuildAction action = build.getAction(PromotedBuildAction.class);
         assertNotNull("no promoted action", action);
 
         final Status promotion = action.getPromotion("promotion");


### PR DESCRIPTION
Impersonate SYSTEM in DownstreamPassCondition's RunListener before calling getAllItems for faster ACL checks, and then verify the original authentication had read permission just before considering a build for promotion.

https://issues.jenkins-ci.org/browse/JENKINS-37368

@reviewbybees
