### PR TITLE
Update Parent POM, resolve upper bound conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.29</version>
+    <version>2.36</version>
   </parent>
 
   <artifactId>promoted-builds</artifactId>
@@ -15,8 +15,8 @@
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Promoted+Builds+Plugin</url>
 
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <developers>
@@ -64,7 +64,17 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.13</version>
+      <version>3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>4.5.3-2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
@@ -114,6 +124,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- TODO: it is something insane, no? -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
       <version>2.33</version>
@@ -124,23 +135,19 @@
       <artifactId>matrix-auth</artifactId>
       <version>1.6</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- Real Upper Bounds dependency issue,
+             See the discussion in https://github.com/jenkinsci/plugin-pom/pull/72 -->
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
+          <artifactId>icon-set</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency> <!-- required to workaround the missing CookieSpecProvider class -->
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/promoted_builds/inheritance/JobPropertyImplSelector.java
+++ b/src/main/java/hudson/plugins/promoted_builds/inheritance/JobPropertyImplSelector.java
@@ -1,7 +1,8 @@
 
 package hudson.plugins.promoted_builds.inheritance;
 
-import org.apache.log4j.Logger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import hudson.Extension;
 import hudson.model.JobProperty;
@@ -19,7 +20,7 @@ import hudson.plugins.promoted_builds.JobPropertyImpl;
 @Extension(optional=true)
 public class JobPropertyImplSelector extends InheritanceSelector<JobProperty<?>> {
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = Logger.getLogger(JobPropertyImplSelector.class);
+    private static final Logger logger = Logger.getLogger(JobPropertyImplSelector.class.getName());
 
     @Override
     public boolean isApplicableFor(Class<?> clazz){
@@ -59,7 +60,7 @@ public class JobPropertyImplSelector extends InheritanceSelector<JobProperty<?>>
             JobPropertyImpl newJobProperty = new JobPropertyImpl(jobPropertyImpl, caller);
             return newJobProperty;
         } catch (Exception ex){
-            logger.error("Error during hacking up JobPropertyImpl", ex );
+            logger.log(Level.WARNING, "Error during hacking up JobPropertyImpl", ex );
         }
         return jobProperty;
     }


### PR DESCRIPTION
After the Maven 3.0 release I was able to cleanup the dependency mess in the plugin. Now it looks better, the plugin bundles only findbugs-annotations-1.3.9-1.jar (parent POM defect IIRC) and promoted-builds.jar 

@reviewbybees