### PR TITLE
[JENKINS-22068] Fail promotion builds instead of hanging when a promotion is built/rebuilt directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
       <artifactId>rebuild</artifactId>
-      <version>1.22</version>
+      <version>1.25</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -1,5 +1,6 @@
 package hudson.plugins.promoted_builds;
 
+import com.sonyericsson.rebuild.RebuildAction;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.console.ConsoleLogFilter;
@@ -73,6 +74,16 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
 
     public Promotion(PromotionProcess project, File buildDir) throws IOException {
         super(project, buildDir);
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+        // JENKINS-22068: Remove any RebuildAction attached to this promotion before PromotionRebuildValidator was added.
+        RebuildAction a = getAction(RebuildAction.class);
+        if (a != null) {
+            getActions().remove(a);
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -288,15 +288,15 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     	return definitions;
     }
 
+    public void doRebuild(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        throw HttpResponses.error(404, "Promotions may not be rebuilt directly");
+    }
+
     public void run() {
         if (getTarget() != null) {
             getStatus().addPromotionAttempt(this);
         }
         run(new RunnerImpl(this));
-    }
-
-    public void doRebuild(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        throw HttpResponses.error(404, "Promotions may not be rebuilt directly");
     }
 
     protected class RunnerImpl extends AbstractRunner {

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -395,12 +395,15 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
         }
 
         protected void post2(BuildListener listener) throws Exception {
+            if (getTarget() == null) {
+                listener.error("No Promotion target, cannot save target or update status");
+                return;
+            }
+
             if(getResult()== Result.SUCCESS)
                 getStatus().onSuccessfulPromotion(Promotion.this);
             // persist the updated build record
-            if (getTarget() != null) {
-                getTarget().save();
-            }
+            getTarget().save();
 
             if (getResult() == Result.SUCCESS) {
                 // we should evaluate any other pending promotions in case

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionRebuildValidator.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionRebuildValidator.java
@@ -29,9 +29,15 @@ import hudson.model.Run;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+/**
+ * Disables the rebuild button for {@link Promotion} objects since rebuilding
+ * is handled separately for them.
+ *
+ * @see Status
+ */
 @Extension
 @Restricted(NoExternalUse.class)
-public class RebuildPromotionSuppressor extends RebuildValidator {
+public class PromotionRebuildValidator extends RebuildValidator {
 
     @Override
     public boolean isApplicable(Run build) {

--- a/src/main/java/hudson/plugins/promoted_builds/RebuildPromotionSuppressor.java
+++ b/src/main/java/hudson/plugins/promoted_builds/RebuildPromotionSuppressor.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.promoted_builds;
+
+import com.sonyericsson.rebuild.RebuildValidator;
+import hudson.Extension;
+import hudson.model.Run;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class RebuildPromotionSuppressor extends RebuildValidator {
+
+    @Override
+    public boolean isApplicable(Run build) {
+        return build instanceof Promotion;
+    }
+
+}

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.promoted_builds;
+
+import com.sonyericsson.rebuild.RebuildAction;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class PromotionRebuildValidatorTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void testPromotionsDoNotHaveRebuildActions() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+
+        // promote if the downstream passes
+        JobPropertyImpl promotion = new JobPropertyImpl(p);
+        p.addProperty(promotion);
+
+        PromotionProcess promo1 = promotion.addProcess("promo1");
+        promo1.conditions.add(new SelfPromotionCondition(false));
+
+        FreeStyleBuild b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        // internally, the promotion is still an asynchronous process. It just happens
+        // right away after the build is complete.
+        Thread.sleep(1000);
+
+        Promotion pb = promo1.getBuilds().iterator().next();
+        assertSame(pb.getTarget(), b);
+
+        assertNull(pb.getAction(RebuildAction.class));
+    }
+
+}

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.promoted_builds;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class PromotionTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void testRebuildPromotionThrowsException() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject("proj1");
+
+        JobPropertyImpl promotion = new JobPropertyImpl(p);
+        p.addProperty(promotion);
+
+        PromotionProcess promo1 = promotion.addProcess("promo1");
+        promo1.conditions.add(new SelfPromotionCondition(false));
+
+        FreeStyleBuild b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        // internally, the promotion is still an asynchronous process. It just happens
+        // right away after the build is complete.
+        Thread.sleep(1000);
+
+        Promotion pb = promo1.getBuilds().getLastBuild();
+        assertSame(pb.getTarget(), b);
+
+        try {
+            r.createWebClient().goTo("job/"+p.getName()+"/1/promotion/"+promo1.getName()+"/promotionBuild/"+pb.getNumber()+"/rebuild");
+            fail("rebuilding a promotion directly should fail");
+        } catch (FailingHttpStatusCodeException x) {
+            assertEquals("wrong status code", 404, x.getStatusCode());
+            assertNotEquals("unexpected content", -1, x.getResponse().getContentAsString().indexOf("Promotions may not be rebuilt directly"));
+        }
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-22068](https://issues.jenkins-ci.org/browse/JENKINS-22068).

This PR does 3 things to fix the issue:
* Promotions with no target now fail when built instead of hanging and blocking the queue.
* Throws a 404 error if a promotion is rebuilt by accessing /rebuild.
* Prevents a RebuildAction from being added to newly created Promotions, so they don't show the "Rebuild" link in the sidebar.

@reviewbybees