### PR TITLE
[JENKINS-47573] Mark extension of class from optional dependency as optional

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PromotionRebuildValidator.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionRebuildValidator.java
@@ -35,7 +35,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @see Status
  */
-@Extension
+@Extension(optional=true)
 @Restricted(NoExternalUse.class)
 public class PromotionRebuildValidator extends RebuildValidator {
 


### PR DESCRIPTION
See [JENKINS-47573](https://issues.jenkins-ci.org/browse/JENKINS-47573).

#107 introduced an [extension](https://github.com/dwnusbaum/promoted-builds-plugin/blob/ca850c37fd636b7bef2c720f7bf55f8b708bffd9/src/main/java/hudson/plugins/promoted_builds/PromotionRebuildValidator.java#L40) of `RebuildValidator` from the optional dependency `rebuild-plugin`.

This PR marks the extension as optional to prevent `NoClassDefFound` errors in the logs.

@reviewbybees