### PR TITLE
Fix a problem of concurrency in one test

### DIFF
--- a/src/test/java/hudson/plugins/promoted_builds/conditions/ManualConditionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/ManualConditionTest.java
@@ -330,7 +330,6 @@ public class ManualConditionTest {
             } catch (FailingHttpStatusCodeException e) {
                 fail();
             }
-            Thread.sleep(2000);
             assertThat(pp.getBuildByNumber(4), nullValue());
         }
     }

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/ManualConditionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/ManualConditionTest.java
@@ -325,11 +325,7 @@ public class ManualConditionTest {
             // Re-execute promotion as unspecified user with Promotion/Promote
             cond.setUsers("non-promoter");
             wc.login("promoter", "promoter");
-            try {
-                wc.goTo(String.format("job/%s/%d/promotion/%s/build?json={}", p.getName(), b.getNumber(), pp.getName()), "");
-            } catch (FailingHttpStatusCodeException e) {
-                fail();
-            }
+            wc.goTo(String.format("job/%s/%d/promotion/%s/build?json={}", p.getName(), b.getNumber(), pp.getName()), "");
             assertThat(pp.getBuildByNumber(4), nullValue());
         }
     }


### PR DESCRIPTION
Without the waiting time, the test is passing only once per 10/20 run in my machine.
It works fine with a simple `Thread.sleep(2000)` but using increment of 50ms could speed up the things and at maximum it waits for 5 seconds.

@dwnusbaum can you please have a look ?
@reviewbybees 