### PR TITLE
Allow expanding and collapsing the promotion history pane

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedProjectAction/index.jelly
@@ -19,9 +19,9 @@
 	          <h2>
 	            <img src="${resURL}/plugin/promoted-builds/icons/32x32/${c.getIcon()}.png"/> <a href="process/${c.name}" class="model-link">${c.name}</a>
 	          </h2>
-	
+
 	          <!-- history of this promotion process -->
-	          <l:pane title="${%Promotion History}">
+	          <l:pane id="${c.name}" title="${%Promotion History}">
 	            <j:forEach var="attempt" items="${it.getPromotionsSummary(c)}">
 	              <tr>
 	                <td class="history-entry">


### PR DESCRIPTION
The pane for the promoted builds history does not have an id and the toggle open/close won't work.
We add an id from the name of the promotion.