### PR TITLE
 Add support for build wrappers in promotions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ freeStyleJob(String jobname) {
               textParam(String parameterName, String defaultValue, String description)
           }
         }
+        wrappers {
+          /* build wrappers, e.g. credentialsBinding */
+        }
         actions {
           shell(String command)
         }
@@ -151,7 +154,7 @@ freeStyleJob(String jobname) {
 }
 ```
 
-See [StepContext](https://jenkinsci.github.io/job-dsl-plugin/#path/job-steps) in the API Viewer for full documentation about the possible actions.
+See [WrapperContext](https://jenkinsci.github.io/job-dsl-plugin/#path/job-wrappers) and [StepContext](https://jenkinsci.github.io/job-dsl-plugin/#path/job-steps) in the API Viewer for full documentation about the possible wrappers and actions.
 
 ### Example
 
@@ -163,6 +166,9 @@ freeStyleJob('test-job') {
         name('Development')
         conditions {
           manual('testuser')
+        }
+        wrappers {
+          timestamps()
         }
         actions {
           shell('echo hello;')

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcess.java
@@ -35,6 +35,8 @@ public final class JobDslPromotionProcess {
     private List<PromotionCondition> conditions = new ArrayList<PromotionCondition>();
 
     private List<Node> buildSteps = new ArrayList<Node>();
+    
+    private List<Node> buildWrappers = new ArrayList<Node>();
 
     public String getName() {
         return name;
@@ -74,6 +76,14 @@ public final class JobDslPromotionProcess {
 
     public void setBuildSteps(List<Node> buildSteps) {
         this.buildSteps = buildSteps;
+    }
+    
+    public void setBuildWrappers(List<Node> buildWrappers) {
+        this.buildWrappers = buildWrappers;
+    }
+
+    public List<Node> getBuildWrappers() {
+        return buildWrappers;
     }
 
 }

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
@@ -1,24 +1,23 @@
 package hudson.plugins.promoted_builds.integrations.jobdsl;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
+import javax.annotation.CheckForNull;
+
+import org.apache.commons.lang.ObjectUtils;
+
 import com.thoughtworks.xstream.converters.MarshallingContext;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
-import com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter;
 import com.thoughtworks.xstream.converters.reflection.ReflectionConverter;
 import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
-import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 
 import groovy.util.Node;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
-import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * XStream Converter for the PromotionProcess for the Job DSL Plugin
@@ -75,19 +74,28 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
             }
             if (promotionProcess.getBuildSteps() != null) {
                 writer.startNode("buildSteps");
-                for (Node node : promotionProcess.getBuildSteps()) {
-                    writer.startNode(node.name().toString());
-                    if (node.value() instanceof Collection) {
-                        for (Object subNode : (Collection) node.value()) {
-                            convertNode((Node) subNode, writer);
-                        }
-                    } else {
-                        writer.setValue(node.value().toString());
-                    }
-                    writer.endNode();
-                }
+                writeNodes(writer, promotionProcess.getBuildSteps());
                 writer.endNode();
             }
+            if (promotionProcess.getBuildWrappers() != null) {
+                writer.startNode("buildWrappers");
+                writeNodes(writer, promotionProcess.getBuildWrappers());
+                writer.endNode();
+            }
+        }
+    }
+
+    private void writeNodes(HierarchicalStreamWriter writer, List<Node> nodes) {
+        for (Node node : nodes) {
+            writer.startNode(node.name().toString());
+            if (node.value() instanceof Collection) {
+                for (Object subNode : (Collection) node.value()) {
+                    convertNode((Node) subNode, writer);
+                }
+            } else {
+                writer.setValue(node.value().toString());
+            }
+            writer.endNode();
         }
     }
 

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContext.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContext.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import javaposse.jobdsl.dsl.Context;
 import javaposse.jobdsl.dsl.helpers.step.StepContext;
-
+import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
 import javaposse.jobdsl.plugin.DslEnvironment;
 
 import static javaposse.jobdsl.plugin.ContextExtensionPoint.executeInContext;
@@ -24,6 +24,8 @@ class PromotionContext implements Context {
     private List<PromotionCondition> conditions = new ArrayList<PromotionCondition>();
     
     private List<Node> actions = new ArrayList<Node>();
+    
+    private List<Node> wrappers = new ArrayList<Node>();
 
     private String icon;
 
@@ -83,6 +85,12 @@ class PromotionContext implements Context {
         executeInContext(actionsClosure, stepContext);
         actions.addAll(stepContext.getStepNodes());
     }
+    
+    public void wrappers(Closure<?> wrappersClosure) {
+        WrapperContext wrapperContext = dslEnvironment.createContext(WrapperContext.class);
+        executeInContext(wrappersClosure, wrapperContext);
+        wrappers.addAll(wrapperContext.getWrapperNodes());
+    }
 
     public List<PromotionCondition> getConditions() {
         return conditions;
@@ -102,6 +110,10 @@ class PromotionContext implements Context {
 
     public String getName() {
         return name;
+    }
+    
+    public List<Node> getWrappers() {
+        return wrappers;
     }
 
     

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
@@ -54,6 +54,7 @@ public class PromotionsExtensionPoint extends ContextExtensionPoint {
             jobDslPromotionProcess.setAssignedLabel(promotionContext.getRestrict());
             jobDslPromotionProcess.setBuildSteps(promotionContext.getActions());
             jobDslPromotionProcess.setConditions(promotionContext.getConditions());
+            jobDslPromotionProcess.setBuildWrappers(promotionContext.getWrappers());
             promotionProcesses.put(processName,jobDslPromotionProcess);
         }
         dslEnvironment.put("promotionProcesses", promotionProcesses);

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
@@ -56,6 +56,17 @@
           </table>
         </f:nested>
       </f:section>
+ 
+      <j:set var="wrappers" value="${descriptor.getApplicableBuildWrappers(it)}" />
+      <j:if test="${!empty(wrappers)}">
+        <f:section title="Promotion environment">
+          <f:nested>
+            <f:descriptorList
+                  descriptors="${wrappers}"
+                  instances="${instance.buildWrappers}" />
+          </f:nested>
+        </f:section>
+      </j:if>
       <f:section title="Actions">
         <f:nested>
           <f:hetero-list  name="buildStep" targetType="${descriptor.promotionProcessType}"

--- a/src/test/java/hudson/plugins/promoted_builds/ConfigurationRoundtripTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/ConfigurationRoundtripTest.java
@@ -26,6 +26,11 @@ package hudson.plugins.promoted_builds;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.promoted_builds.conditions.DownstreamPassCondition;
 import hudson.tasks.JavadocArchiver;
+
+import java.util.ArrayList;
+
+import org.jenkinsci.plugins.configfiles.buildwrapper.ConfigFileBuildWrapper;
+import org.jenkinsci.plugins.configfiles.buildwrapper.ManagedFile;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -60,6 +65,7 @@ public class ConfigurationRoundtripTest {
         assertEquals(1,pp.getItems().size());
         proc.conditions.add(new DownstreamPassCondition(down.getName()));
         proc.getBuildSteps().add(new JavadocArchiver("somedir",true));
+        proc.getBuildWrappersList().add(new ConfigFileBuildWrapper(new ArrayList<ManagedFile>()));
         proc.icon = "star-blue";
 
         // round trip
@@ -77,6 +83,8 @@ public class ConfigurationRoundtripTest {
         JavadocArchiver ja = (JavadocArchiver)proc.getBuildSteps().get(0);
         assertEquals("somedir",ja.getJavadocDir());
         assertTrue(ja.isKeepAll());
+        ConfigFileBuildWrapper buildWrapper = (ConfigFileBuildWrapper) proc.getBuildWrappersList().get(0);
+        assertNotNull(buildWrapper);
         assertEquals("star-blue", proc.icon);
     }
 

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
@@ -1,0 +1,54 @@
+package hudson.plugins.promoted_builds;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.TestBuildWrapper;
+
+import hudson.Functions;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+
+/**
+ * Tests for build wrapper functionality in promotion.
+ * @author patrick.schlebusch
+ */
+public class PromotionBuildWrapperTest {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Test
+    public void testApplyBuildWrapper() throws Exception {        
+        FreeStyleProject project = j.createFreeStyleProject();
+        JobPropertyImpl jobProperty = new JobPropertyImpl(project);
+        project.addProperty(jobProperty);
+        
+        PromotionProcess promotion = jobProperty.addProcess("test");
+        
+        TestBuildWrapper buildWrapper = new TestBuildWrapper();
+        promotion.getBuildWrappersList().add(buildWrapper);
+        promotion.getBuildSteps().add(Functions.isWindows()
+                ? new BatchFile("echo Hello, world")
+                : new Shell("echo Hello, world"));
+        
+        // trigger build
+        FreeStyleBuild build = j.assertBuildStatusSuccess(project.scheduleBuild2(0).get());
+        // trigger promotion
+        promotion.promote(build, new Cause.UserIdCause(), new ManualPromotionBadge());
+        Thread.sleep(1000);
+        
+        assertEquals(1,promotion.getBuilds().size());
+        Promotion promotionBuild = promotion.getBuilds().get(0);
+        assertSame(promotionBuild.getTarget(), build);
+        assertEquals(Result.SUCCESS, buildWrapper.buildResultInTearDown);
+    }
+
+}

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
@@ -163,6 +163,7 @@ public class PromotionProcessTest {
                 assertEquals("foo", p.getName());
                 assertEquals("star-gold", p.getIcon());
                 assertEquals(1, p.conditions.size());
+                assertEquals(0, p.getBuildWrappers().size());
                 assertNotNull(p.conditions.get(SelfPromotionCondition.class));
                 System.out.println(Items.XSTREAM2.toXML(p));
                 return null;

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverterTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverterTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
@@ -43,6 +44,10 @@ public class JobDslPromotionProcessConverterTest  {
         buildSteps.add(node2);
         pp.setBuildSteps(buildSteps);
         pp.setConditions(conditions);
+        List<Node> buildWrappers = new ArrayList<Node>();
+        Node bwNode = new Node(null, "hudson.test.buildwrapper.ExampleWrapper");
+        buildWrappers.add(bwNode);
+        pp.setBuildWrappers(buildWrappers);
         // When
         XSTREAM.registerConverter(new JobDslPromotionProcessConverter(XSTREAM.getMapper(), XSTREAM.getReflectionProvider()));
         String xml = XSTREAM.toXML(pp);
@@ -50,5 +55,7 @@ public class JobDslPromotionProcessConverterTest  {
         assertNotNull(xml);
         System.out.println(xml);
         assertTrue(StringUtils.contains(xml, "hudson.plugins.promoted__builds.PromotionProcess"));
+        assertTrue(Pattern.compile("<buildWrappers>\\s+<hudson\\.test\\.buildwrapper\\.ExampleWrapper/>\\s+</buildWrappers>")
+                    .matcher(xml).find());
     }
 }

--- a/src/test/resources/buildwrapper-example-dsl.groovy
+++ b/src/test/resources/buildwrapper-example-dsl.groovy
@@ -1,0 +1,20 @@
+freeStyleJob('build-wrapper-test') {
+    properties {
+        promotions {
+            promotion {
+                name('build-wrapper-promotion')
+                conditions {
+                    manual('tester')
+                }
+                wrappers {
+                    timestamps()
+                }
+                actions {
+                    actions {
+                        shell('echo hello;')
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for build wrappers in the promotion processes. The build wrappers can also be specified for the promotions via JobDSL.
The build wrappers can be configured in a new "Promotion Environment" section of the promotion process configuration.

This is useful e.g. in order to be able to prepare an environment or inject secrets for the promotion.

There are a number of issues calling for this support:
* https://issues.jenkins-ci.org/browse/JENKINS-23977
* https://issues.jenkins-ci.org/browse/JENKINS-25526
* https://issues.jenkins-ci.org/browse/JENKINS-43656

For [JENKINS-14169](https://issues.jenkins-ci.org/browse/JENKINS-14169) this change might provide a workaround by allowing to inject environment vars for the promotion either from the configuration or by injecting them from a file passed to the promotion process.