### PR TITLE
[JENKINS-57903] - Introduce foundation logic for Pipeline promotion jobs

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionCondition.java
@@ -1,0 +1,48 @@
+package hudson.plugins.promoted_builds;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.*;
+import hudson.plugins.promoted_builds.util.JenkinsHelper;
+
+import javax.annotation.CheckForNull;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class PipelinePromotionCondition implements ExtensionPoint, Describable<PipelinePromotionCondition> {
+
+    //for those promotions that don't satisfy the desired Promotion Conditions
+    @CheckForNull
+    public PromotionBadge isMet(Run<?,?> run, TaskListener listener){
+        return null;
+    }
+
+    //The method is used by the Conditions to label those who satisfy the presented Promotion Conditions.
+    public PromotionBadge isMet(PipelinePromotionProcess promotionProcess, Run<?,?> run, TaskListener listener){
+        return isMet(run,listener);
+    }
+
+    //Loads the descriptor with the URL
+    public PipelinePromotionConditionDescriptor getDescriptor() {
+        return (PipelinePromotionConditionDescriptor) JenkinsHelper.getInstance().getDescriptor(getClass());
+    }
+
+    //Holds a set of Descriptors
+    public static DescriptorExtensionList<PipelinePromotionCondition,PipelinePromotionConditionDescriptor> all() {
+        return JenkinsHelper.getInstance().<PipelinePromotionCondition,PipelinePromotionConditionDescriptor>getDescriptorList(PipelinePromotionCondition.class);
+    }
+
+    /**
+     * Returns a subset of {@link PipelinePromotionConditionDescriptor}s that applies to the given project.
+     */
+    //Required Promotion Conditions to be satisfied for Promotion is being defined here.
+    public static List<PipelinePromotionConditionDescriptor> getApplicableTriggers(Job<?,?> p) {
+        List<PipelinePromotionConditionDescriptor> r = new ArrayList<PipelinePromotionConditionDescriptor>();
+        for (PipelinePromotionConditionDescriptor t : all()) {
+            if(t.isApplicable(p))
+                r.add(t);
+        }
+        return r;
+    }
+
+}

--- a/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionConditionDescriptor.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionConditionDescriptor.java
@@ -1,0 +1,22 @@
+package hudson.plugins.promoted_builds;
+
+import hudson.model.Descriptor;
+import hudson.model.Job;
+
+public abstract class PipelinePromotionConditionDescriptor extends Descriptor<PipelinePromotionCondition> {
+
+    protected PipelinePromotionConditionDescriptor(Class<? extends PipelinePromotionCondition> clazz) {
+        super(clazz);
+    }
+
+    protected PipelinePromotionConditionDescriptor() {
+        super();
+    }
+
+    /**
+     * Returns true if this condition is applicable to the given project.
+     *
+     * @return true to allow user to configure this promotion condition for the given project.
+     */
+    public abstract boolean isApplicable(Job<?, ?> item);
+}

--- a/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PipelinePromotionProcess.java
@@ -1,0 +1,11 @@
+package hudson.plugins.promoted_builds;
+
+import hudson.model.Job;
+
+import java.util.List;
+
+public class PipelinePromotionProcess {
+    public List<PipelinePromotionConditionDescriptor> getApplicableConditions(Job<?,?> p) {
+        return p==null ? PipelinePromotionCondition.all() : PipelinePromotionCondition.getApplicableTriggers(p);
+    }
+}


### PR DESCRIPTION
Create three classes analogous to PromotionCondition, PromotionConditionDescriptor and PromotionProcess. The PipelinePromotionProcess is the same as PromotionRun but without methods for isMet() condition but still consider the PromotionBadge to already have been refactored. Waiting for your response at: https://github.com/jenkinsci/promoted-builds-plugin/pull/128/commits/c3965f04f1b282376f2199906a0b783bc8743098

See [JENKINS-57903](https://issues.jenkins-ci.org/browse/JENKINS-57903).

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [ ] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] ~Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files~
- [ ] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@oleg-nenashev @jonbrohauge @bicschneider  @jenkinsci/gsoc2019-promotion-for-pipeline 

