### PR TITLE
[JENKINS-59600, JENKINS-58337, JENKINS-58534] - Fix promotion log visualization with Jenkins 2.138.2+ (regression in 3.3)

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
@@ -41,7 +41,7 @@ public class KeepBuildForeverAction extends Notifier {
             console.println(Messages.KeepBuildForEverAction_console_promotionNotGoodEnough(build.getResult()));
             return true;
         }
-        AbstractBuild promoted = ((Promotion) build).getTarget();
+        AbstractBuild promoted = ((Promotion) build).getTargetBuild();
         console.println(Messages.KeepBuildForEverAction_console_keepingBuild());
         promoted.keepLog();
         return true;

--- a/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
+++ b/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
@@ -4,7 +4,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.maven.RedeployPublisher;
-import hudson.maven.reporters.MavenAbstractArtifactRecord;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.plugins.promoted_builds.Promotion;
@@ -26,7 +25,7 @@ public class RedeployBatchTaskPublisher extends RedeployPublisher {
 
     /*@Override*/
     protected MavenModuleSetBuild getMavenBuild(AbstractBuild<?,?> build) {
-        return super.getMavenBuild(((Promotion) build).getTarget());
+        return super.getMavenBuild(((Promotion) build).getTargetBuild());
     }
 
     @Extension(optional = true)

--- a/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
@@ -8,7 +8,7 @@
     <l:side-panel>
       <l:tasks>
         <l:task icon="images/24x24/up.png"
-                href="${h.getNearestAncestorUrl(request,it.target)}/promotion/"
+                href="${h.getNearestAncestorUrl(request,it.targetBuild)}/promotion/"
                 title="${%Back to Promotion Status}" />
       </l:tasks>
     </l:side-panel>

--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
@@ -58,7 +58,7 @@ public class PromotedBuildRebuildParameterProviderTest {
         j.waitUntilNoActivity();
 
         // verify that promotion happened
-        Assert.assertSame(proc.getBuilds().getLastBuild().getTarget(), b1);
+        Assert.assertSame(proc.getBuilds().getLastBuild().getTargetBuild(), b1);
 
         // job with parameter
         FreeStyleProject p2 = j.createFreeStyleProject("paramjob");

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
@@ -47,7 +47,7 @@ public class PromotionBuildWrapperTest {
         
         assertEquals(1,promotion.getBuilds().size());
         Promotion promotionBuild = promotion.getBuilds().get(0);
-        assertSame(promotionBuild.getTarget(), build);
+        assertSame(promotionBuild.getTargetBuild(), build);
         assertEquals(Result.SUCCESS, buildWrapper.buildResultInTearDown);
     }
 

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
@@ -88,7 +88,7 @@ public class PromotionProcessTest {
 
         {// verify that it promoted the right stuff
             Promotion pb = proc.getBuilds().get(0);
-            assertSame(pb.getTarget(),up1);
+            assertSame(pb.getTargetBuild(),up1);
             PromotedBuildAction badge = (PromotedBuildAction) up1.getBadgeActions().get(0);
             assertTrue(badge.contains(proc));
         }
@@ -134,7 +134,7 @@ public class PromotionProcessTest {
 
         {// verify that it promoted the right stuff
             Promotion pb = proc.getBuilds().get(0);
-            assertSame(pb.getTarget(),up2);
+            assertSame(pb.getTargetBuild(),up2);
             PromotedBuildAction badge = (PromotedBuildAction) up2.getBadgeActions().get(0);
             assertTrue(badge.contains(proc));
         }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
@@ -54,7 +54,7 @@ public class PromotionRebuildValidatorTest {
         Thread.sleep(1000);
 
         Promotion pb = promo1.getBuilds().iterator().next();
-        assertSame(pb.getTarget(), b);
+        assertSame(pb.getTargetBuild(), b);
 
         assertNull(pb.getAction(RebuildAction.class));
     }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTargetActionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTargetActionTest.java
@@ -46,6 +46,6 @@ public class PromotionTargetActionTest {
 
         up.renameTo("up2");
 
-        assertSame(b,p.getTarget());
+        assertSame(b,p.getTargetBuild());
     }
 }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
@@ -58,7 +58,7 @@ public class PromotionTest {
         Thread.sleep(1000);
 
         Promotion pb = promo1.getBuilds().getLastBuild();
-        assertSame(pb.getTarget(), b);
+        assertSame(pb.getTargetBuild(), b);
 
         JenkinsRule.WebClient wc = r.createWebClient();
         wc.goTo(pb.getUrl()); // spot-check that promotion itself is accessible

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
@@ -57,10 +57,10 @@ public class SelfPromotionTest {
 
         // verify that both promotions happened
         Promotion pb = promo1.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertTrue(badge.contains(promo1));
@@ -99,7 +99,7 @@ public class SelfPromotionTest {
         assertTrue(promo1.getBuilds().isEmpty());
 
         Promotion pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertFalse(badge.contains(promo1));

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/inheritance/SelfPromotionInheritanceTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/inheritance/SelfPromotionInheritanceTest.java
@@ -71,10 +71,10 @@ public class SelfPromotionInheritanceTest  {
         
         // verify that both promotions happened
         Promotion pb = promo1.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertTrue(badge.contains(promo1));
@@ -118,7 +118,7 @@ public class SelfPromotionInheritanceTest  {
         assertTrue(promo1.getBuilds().isEmpty());
 
         Promotion pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTarget(),b);
+        assertSame(pb.getTargetBuild(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertFalse(badge.contains(promo1));

--- a/src/test/java/hudson/plugins/promoted_builds/tokenmacro/PromotedEnvVarTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/tokenmacro/PromotedEnvVarTokenMacroTest.java
@@ -28,7 +28,6 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
-import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -45,9 +44,8 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-import hudson.util.StreamTaskListener;
+
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -137,7 +135,7 @@ public class PromotedEnvVarTokenMacroTest {
                 throws InterruptedException, IOException {
             if (build instanceof Promotion) {
                 // TODO: It seems to be a bug in the test suite
-                AbstractBuild<?, ?> target = ((Promotion)build).getTarget();
+                AbstractBuild<?, ?> target = ((Promotion)build).getTargetBuild();
                 return performWithParentBuild(build, listener);
             }
             return false;


### PR DESCRIPTION
See [JENKINS-59600](https://issues.jenkins-ci.org/browse/JENKINS-59600).

Since Jenkins 2.138.2 and 2.147, `Run` implements `StaplerProxy` and therefore has a magic `getTarget` method. This clashes with the existing method in `Promotion`, so rename it (but keep the exported name for remote API stability).

This PR underwent only minimal manual testing.

### Your checklist for this pull request

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [ ] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [ ] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [ ] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@mention

