### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
 
   <name>Jenkins promoted builds plugin</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/Promoted+Builds+Plugin</url>
+  <url>https://github.com/jenkinsci/promoted-builds-plugin</url>
 
   <properties>
     <jenkins.version>2.138.4</jenkins.version>


### PR DESCRIPTION
See [JENKINS-59172](https://issues.jenkins-ci.org/browse/JENKINS-59172). The change makes the GitHub repo an official source of the documentation. Wiki will be deprecated once changelogs are moved in a separate PR

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [ ] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [ ] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [ ] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@mention

