### PR TITLE
[JENKINS-59704] - Restore binary compatibility with Promoted Builds 3.3 and older

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,10 @@
   <url>https://github.com/jenkinsci/promoted-builds-plugin</url>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <!-- Last version before https://jenkins.io/security/advisory/2018-08-15/ which causes instabilities
+         due to Promotion#getTarget(). And we cannot just remove it without breaking binary compatibility
+         (see JENKINS-59704, JENKINS-59773 and so on for the fallout in 3.4)-->
+    <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
     <findbugs.effort>Max</findbugs.effort>
     <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>

--- a/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/KeepBuildForeverAction.java
@@ -41,7 +41,7 @@ public class KeepBuildForeverAction extends Notifier {
             console.println(Messages.KeepBuildForEverAction_console_promotionNotGoodEnough(build.getResult()));
             return true;
         }
-        AbstractBuild promoted = ((Promotion) build).getTargetBuild();
+        AbstractBuild promoted = ((Promotion) build).getTargetBuildOrFail();
         console.println(Messages.KeepBuildForEverAction_console_keepingBuild());
         promoted.keepLog();
         return true;

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -83,7 +83,6 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
      * @return
      *      {@code null} if there's no such object. For example, if the build has already garbage collected.
      */
-    @Exported
     @CheckForNull
     public AbstractBuild<?,?> getTargetBuild() {
         return getTarget();

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -77,7 +77,6 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
         super(project, buildDir);
     }
 
-
     /**
      * Gets the build that this promotion promoted.
      * @since 3.4
@@ -92,8 +91,24 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
 
     /**
      * Gets the build that this promotion promoted.
+     * @since 3.5
+     * @return Target build
+     * @throws IllegalStateException There is no target build
+     */
+    @Nonnull
+    public AbstractBuild<?,?> getTargetBuildOrFail() {
+        final AbstractBuild<?, ?> target = getTarget();
+        if (target == null) {
+            throw new IllegalStateException("There is no target build associated with " + this +
+                    ". Most probably, the build has been already removed");
+        }
+        return target;
+    }
+
+    /**
+     * Gets the build that this promotion promoted.
      *
-     * @deprecated Use {@link #getTargetBuild()}. This method will be removed once the baseline is updated in Promoted Builds 4.0
+     * @deprecated Use {@link #getTargetBuildOrFail()} or {@link #getTargetBuild()}. This method will be removed once the baseline is updated in Promoted Builds 4.0
      * @return
      *      null if there's no such object. For example, if the build has already garbage collected.
      */
@@ -106,12 +121,12 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     }
 
     @Override public AbstractBuild<?,?> getRootBuild() {
-        return getTargetBuild().getRootBuild();
+        return getTargetBuildOrFail().getRootBuild();
     }
 
     @Override
     public String getUrl() {
-        return getTargetBuild().getUrl() + "promotion/" + getParent().getName() + "/promotionBuild/" + getNumber() + "/";
+        return getTargetBuildOrFail().getUrl() + "promotion/" + getParent().getName() + "/promotionBuild/" + getNumber() + "/";
     }
 
     /**
@@ -119,7 +134,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
      * performed for a build, including this {@link Promotion}.
      */
     public Status getStatus() {
-        return getTargetBuild().getAction(PromotedBuildAction.class).getPromotion(getParent().getName());
+        return getTargetBuildOrFail().getAction(PromotedBuildAction.class).getPromotion(getParent().getName());
     }
 
     @Override
@@ -128,7 +143,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
 
         // Augment environment with target build's information
         String rootUrl = Jenkins.get().getRootUrl();
-        AbstractBuild<?, ?> target = getTargetBuild();
+        AbstractBuild<?, ?> target = getTargetBuildOrFail();
         if(rootUrl!=null)
             e.put("PROMOTED_URL",rootUrl+target.getUrl());
         e.put("PROMOTED_JOB_NAME", target.getParent().getName());
@@ -308,7 +323,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     }
 
     public void run() {
-        if (getTargetBuild() != null) {
+        if (getTargetBuildOrFail() != null) {
             getStatus().addPromotionAttempt(this);
         }
         run(new RunnerImpl(this));
@@ -337,7 +352,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
                         rootPath.child(getEnvironment(listener).expand(customWorkspace)));
             }
 
-            TopLevelItem item = (TopLevelItem) getTargetBuild().getProject();
+            TopLevelItem item = (TopLevelItem) getTargetBuildOrFail().getProject();
             FilePath workspace = n.getWorkspaceFor(item);
             if (workspace == null) {
                 throw new IOException("Cannot retrieve workspace for " + item + " on the node " + n);
@@ -346,7 +361,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
         }
 
         protected Result doRun(BuildListener listener) throws Exception {
-            AbstractBuild<?, ?> target = getTargetBuild();
+            AbstractBuild<?, ?> target = getTargetBuildOrFail();
 
             OutputStream logger = listener.getLogger();
             AbstractProject rootProject = project.getRootProject();
@@ -426,14 +441,14 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
             if(getResult()== Result.SUCCESS)
                 getStatus().onSuccessfulPromotion(Promotion.this);
             // persist the updated build record
-            getTargetBuild().save();
+            getTargetBuildOrFail().save();
 
             if (getResult() == Result.SUCCESS) {
                 // we should evaluate any other pending promotions in case
                 // they had a condition on this promotion
-                PromotedBuildAction pba = getTargetBuild().getAction(PromotedBuildAction.class);
+                PromotedBuildAction pba = getTargetBuildOrFail().getAction(PromotedBuildAction.class);
                 for (PromotionProcess pp : pba.getPendingPromotions()) {
-                    pp.considerPromotion2(getTargetBuild());
+                    pp.considerPromotion2(getTargetBuildOrFail());
                 }
 
                 // tickle PromotionTriggers

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -77,14 +77,30 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
         super(project, buildDir);
     }
 
+
+    /**
+     * Gets the build that this promotion promoted.
+     * @since 3.4
+     * @return
+     *      {@code null} if there's no such object. For example, if the build has already garbage collected.
+     */
+    @Exported
+    @CheckForNull
+    public AbstractBuild<?,?> getTargetBuild() {
+        return getTarget();
+    }
+
     /**
      * Gets the build that this promotion promoted.
      *
+     * @deprecated Use {@link #getTargetBuild()}. This method will be removed once the baseline is updated in Promoted Builds 4.0
      * @return
      *      null if there's no such object. For example, if the build has already garbage collected.
      */
-    @Exported(name = "target")
-    public AbstractBuild<?,?> getTargetBuild() {
+    @Exported
+    @Deprecated
+    @CheckForNull
+    public AbstractBuild<?,?> getTarget() {
         PromotionTargetAction pta = getAction(PromotionTargetAction.class);
         return pta == null ? null : pta.resolve(this);
     }

--- a/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
+++ b/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
@@ -25,7 +25,7 @@ public class RedeployBatchTaskPublisher extends RedeployPublisher {
 
     /*@Override*/
     protected MavenModuleSetBuild getMavenBuild(AbstractBuild<?,?> build) {
-        return super.getMavenBuild(((Promotion) build).getTargetBuild());
+        return super.getMavenBuild(((Promotion) build).getTargetBuildOrFail());
     }
 
     @Extension(optional = true)

--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
@@ -58,7 +58,7 @@ public class PromotedBuildRebuildParameterProviderTest {
         j.waitUntilNoActivity();
 
         // verify that promotion happened
-        Assert.assertSame(proc.getBuilds().getLastBuild().getTargetBuild(), b1);
+        Assert.assertSame(proc.getBuilds().getLastBuild().getTargetBuildOrFail(), b1);
 
         // job with parameter
         FreeStyleProject p2 = j.createFreeStyleProject("paramjob");

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionBuildWrapperTest.java
@@ -47,7 +47,7 @@ public class PromotionBuildWrapperTest {
         
         assertEquals(1,promotion.getBuilds().size());
         Promotion promotionBuild = promotion.getBuilds().get(0);
-        assertSame(promotionBuild.getTargetBuild(), build);
+        assertSame(promotionBuild.getTargetBuildOrFail(), build);
         assertEquals(Result.SUCCESS, buildWrapper.buildResultInTearDown);
     }
 

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
@@ -88,7 +88,7 @@ public class PromotionProcessTest {
 
         {// verify that it promoted the right stuff
             Promotion pb = proc.getBuilds().get(0);
-            assertSame(pb.getTargetBuild(),up1);
+            assertSame(pb.getTargetBuildOrFail(),up1);
             PromotedBuildAction badge = (PromotedBuildAction) up1.getBadgeActions().get(0);
             assertTrue(badge.contains(proc));
         }
@@ -134,7 +134,7 @@ public class PromotionProcessTest {
 
         {// verify that it promoted the right stuff
             Promotion pb = proc.getBuilds().get(0);
-            assertSame(pb.getTargetBuild(),up2);
+            assertSame(pb.getTargetBuildOrFail(),up2);
             PromotedBuildAction badge = (PromotedBuildAction) up2.getBadgeActions().get(0);
             assertTrue(badge.contains(proc));
         }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionRebuildValidatorTest.java
@@ -54,7 +54,7 @@ public class PromotionRebuildValidatorTest {
         Thread.sleep(1000);
 
         Promotion pb = promo1.getBuilds().iterator().next();
-        assertSame(pb.getTargetBuild(), b);
+        assertSame(pb.getTargetBuildOrFail(), b);
 
         assertNull(pb.getAction(RebuildAction.class));
     }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTargetActionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTargetActionTest.java
@@ -46,6 +46,6 @@ public class PromotionTargetActionTest {
 
         up.renameTo("up2");
 
-        assertSame(b,p.getTargetBuild());
+        assertSame(b,p.getTargetBuildOrFail());
     }
 }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
@@ -64,7 +64,7 @@ public class PromotionTest {
         Thread.sleep(1000);
 
         Promotion pb = promo1.getBuilds().getLastBuild();
-        assertSame(pb.getTargetBuild(), b);
+        assertSame(pb.getTargetBuildOrFail(), b);
 
         JenkinsRule.WebClient wc = r.createWebClient();
         wc.goTo(pb.getUrl()); // spot-check that promotion itself is accessible
@@ -98,7 +98,7 @@ public class PromotionTest {
         Thread.sleep(1000);
 
         Promotion pb = promo1.getBuilds().getLastBuild();
-        assertSame(pb.getTargetBuild(), b);
+        assertSame(pb.getTargetBuildOrFail(), b);
 
         JenkinsRule.WebClient wc = r.createWebClient();
         final Page page = wc.getPage( r.getURL() + "/" + pb.getUrl() + "consoleText");// spot-check that promotion itself is accessible

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
@@ -25,14 +25,20 @@ package hudson.plugins.promoted_builds;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.net.URL;
@@ -72,6 +78,31 @@ public class PromotionTest {
             //TODO(oleg_nenashev): Another error will be returned since 2.107. As long as URL is rejected, we do not really care much
             // assertNotEquals("unexpected content", -1, x.getResponse().getContentAsString().indexOf("Promotions may not be rebuilt directly"));
         }
+    }
+
+    @Test
+    @Issue("JENKINS-59600")
+    public void testPromotionLog() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject("proj1");
+
+        JobPropertyImpl promotion = new JobPropertyImpl(p);
+        p.addProperty(promotion);
+
+        PromotionProcess promo1 = promotion.addProcess("promo1");
+        promo1.getBuildSteps().add(Functions.isWindows() ? new BatchFile("echo ABCDEFGH") : new Shell("echo ABCDEFGH"));
+        promo1.conditions.add(new SelfPromotionCondition(false));
+
+        FreeStyleBuild b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        // internally, the promotion is still an asynchronous process. It just happens
+        // right away after the build is complete.
+        Thread.sleep(1000);
+
+        Promotion pb = promo1.getBuilds().getLastBuild();
+        assertSame(pb.getTargetBuild(), b);
+
+        JenkinsRule.WebClient wc = r.createWebClient();
+        final Page page = wc.getPage( r.getURL() + "/" + pb.getUrl() + "consoleText");// spot-check that promotion itself is accessible
+        assertThat(pb.getUrl() + "/consoleText + is not a promotion log", page.getWebResponse().getContentAsString(), CoreMatchers.containsString("ABCDEFGH"));
     }
 
 }

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/SelfPromotionTest.java
@@ -57,10 +57,10 @@ public class SelfPromotionTest {
 
         // verify that both promotions happened
         Promotion pb = promo1.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertTrue(badge.contains(promo1));
@@ -99,7 +99,7 @@ public class SelfPromotionTest {
         assertTrue(promo1.getBuilds().isEmpty());
 
         Promotion pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertFalse(badge.contains(promo1));

--- a/src/test/java/hudson/plugins/promoted_builds/conditions/inheritance/SelfPromotionInheritanceTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/conditions/inheritance/SelfPromotionInheritanceTest.java
@@ -71,10 +71,10 @@ public class SelfPromotionInheritanceTest  {
         
         // verify that both promotions happened
         Promotion pb = promo1.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertTrue(badge.contains(promo1));
@@ -118,7 +118,7 @@ public class SelfPromotionInheritanceTest  {
         assertTrue(promo1.getBuilds().isEmpty());
 
         Promotion pb = promo2.getBuilds().get(0);
-        assertSame(pb.getTargetBuild(),b);
+        assertSame(pb.getTargetBuildOrFail(),b);
 
         PromotedBuildAction badge = (PromotedBuildAction) b.getBadgeActions().get(0);
         assertFalse(badge.contains(promo1));

--- a/src/test/java/hudson/plugins/promoted_builds/tokenmacro/PromotedEnvVarTokenMacroTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/tokenmacro/PromotedEnvVarTokenMacroTest.java
@@ -135,7 +135,7 @@ public class PromotedEnvVarTokenMacroTest {
                 throws InterruptedException, IOException {
             if (build instanceof Promotion) {
                 // TODO: It seems to be a bug in the test suite
-                AbstractBuild<?, ?> target = ((Promotion)build).getTargetBuild();
+                AbstractBuild<?, ?> target = ((Promotion)build).getTargetBuildOrFail();
                 return performWithParentBuild(build, listener);
             }
             return false;


### PR DESCRIPTION
- [x] [JENKINS-59704] - Restore binary compatibility with Promoted Builds 3.3 and older
* [x] [JENKINS-59600] - Create a direct unit test for promotion build access by URL
* [x] [JENKINS-59704] - Downgrade the Jenkins core dependency to 2.121.1 to prevent JENKINS-59600 from reappearing in the new release

CC @daniel-beck @froque 
