### PR TITLE
Fix incompatibility with Jenkins 2.266 and higher in test code.

### DIFF
--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslManualConditionConverterTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslManualConditionConverterTest.java
@@ -1,14 +1,15 @@
 package hudson.plugins.promoted_builds.integrations.jobdsl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 import com.thoughtworks.xstream.XStream;
 
 import hudson.util.XStream2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class JobDslManualConditionConverterTest {
     
@@ -21,10 +22,11 @@ public class JobDslManualConditionConverterTest {
         mc.setUsers("testusers");
         //When
         XSTREAM.registerConverter(new ManualConditionConverter(XSTREAM.getMapper(), XSTREAM.getReflectionProvider()));
+        XSTREAM.processAnnotations(new Class<?>[] {JobDslManualCondition.class});
         String xml =  XSTREAM.toXML(mc);
         //Then
-        assertNotNull(xml);
-        System.out.println(xml);
-        assertTrue(StringUtils.contains(xml, "hudson.plugins.promoted__builds.conditions.ManualCondition"));
+        assertThat(xml,
+                   allOf(notNullValue(),
+                         containsString("hudson.plugins.promoted__builds.conditions.ManualCondition")));
     }
 }

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverterTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverterTest.java
@@ -1,13 +1,8 @@
 package hudson.plugins.promoted_builds.integrations.jobdsl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 import com.thoughtworks.xstream.XStream;
@@ -16,6 +11,12 @@ import groovy.util.Node;
 import hudson.plugins.promoted_builds.PromotionCondition;
 import hudson.plugins.promoted_builds.conditions.SelfPromotionCondition;
 import hudson.util.XStream2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class JobDslPromotionProcessConverterTest  {
 
@@ -50,12 +51,12 @@ public class JobDslPromotionProcessConverterTest  {
         pp.setBuildWrappers(buildWrappers);
         // When
         XSTREAM.registerConverter(new JobDslPromotionProcessConverter(XSTREAM.getMapper(), XSTREAM.getReflectionProvider()));
+        XSTREAM.processAnnotations(new Class<?>[] {JobDslPromotionProcess.class});
         String xml = XSTREAM.toXML(pp);
         // Then
-        assertNotNull(xml);
-        System.out.println(xml);
-        assertTrue(StringUtils.contains(xml, "hudson.plugins.promoted__builds.PromotionProcess"));
-        assertTrue(Pattern.compile("<buildWrappers>\\s+<hudson\\.test\\.buildwrapper\\.ExampleWrapper/>\\s+</buildWrappers>")
-                    .matcher(xml).find());
+        assertThat(xml,
+                   allOf(notNullValue(),
+                         containsString("hudson.plugins.promoted__builds.PromotionProcess"),
+                         matchesPattern("(?s).*<buildWrappers>\\s+<hudson\\.test\\.buildwrapper\\.ExampleWrapper/>\\s+</buildWrappers>.*")));
     }
 }


### PR DESCRIPTION
both JobDslManualConditionConverterTest and JobDslPromotionProcessConverterTest would fail when run against a newer Jenkins core (for example via the PCT).  The cause was that annotations are no longer automatically processed when serialising / deserialising code.
Fixed this so that we regestier the classes wit interesting annotations.

Also updated the test to use hamcreset to get better errors than binary
pass/fail


<!-- Please describe your pull request here -->

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@oleg-nenashev 

