### PR TITLE
[JENKINS-42816] use agent terminology and fix help for label.

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
+++ b/src/main/resources/hudson/plugins/promoted_builds/Messages.properties
@@ -25,7 +25,7 @@ JobPropertyImpl.ValidateRequired=Required
 JobPropertyImpl.LabelString.InvalidBooleanExpression=\
   Invalid boolean expression: {0}
 JobPropertyImpl.LabelString.NoMatch=\
-  There's no slave/cloud that matches this assignment
+  There's no agent/cloud that matches this assignment
 KeepBuildForEverAction.descriptor.displayName=Keep Build Forever
 KeepBuildForEverAction.console.notPromotion=This build is not a promotion, how did we get here? Not keeping build.
 KeepBuildForEverAction.console.promotionNotGoodEnough=Promotion build result [{0}] is not good enough. Not keeping build.

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/help-assignedLabelString.html
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/help-assignedLabelString.html
@@ -1,12 +1,12 @@
 <div>
-    If you want to always run this promotion process on a specific node/slave, just specify its name.
+    If you want to always run this promotion process on a specific node/agent, just specify its name.
     If not specified, the same label which the promoted build used can be used.
     This works well when you have a small number of nodes.
 
     <p>
-    As the size of the cluster grows, it becomes useful not to tie projects to specific slaves,
-    as it hurts resource utilization when slaves may come and go. For such situation, assign labels
-    to slaves to classify their capabilities and characteristics, and specify a boolean expression
+    As the size of the cluster grows, it becomes useful not to tie projects to specific agents,
+    as it hurts resource utilization when agents may come and go. For such situation, assign labels
+    to agents to classify their capabilities and characteristics, and specify a boolean expression
     over those labels to decide where to run.
 
     <h3>Valid Operators</h3>
@@ -32,15 +32,15 @@
         <dt>a -> b</dt>
         <dd>
             "implies" operator. Equivalent to <tt>!a|b</tt>.
-            For example, <tt>windows->x64</tt> could be thought of as "if run on a Windows slave,
-            that slave must be 64bit." It still allows Jenkins to run this build on linux.
+            For example, <tt>windows->x64</tt> could be thought of as "if run on a Windows agent,
+            that agent must be 64bit." It still allows Jenkins to run this build on linux.
         </dd>
 
         <dt>a &lt;-> b</dt>
         <dd>
             "if and only if" operator. Equivalent to <tt>a&amp;&amp;b || !a&amp;&amp;!b</tt>.
-            For example, <tt>windows->sfbay</tt> could be thought of as "if run on a Windows slave,
-            that slave must be in the SF bay area, but if not on Windows, it must not be in the bay area."
+            For example, <tt>windows->sfbay</tt> could be thought of as "if run on a Windows agent,
+            that agent must be in the SF bay area, but if not on Windows, it must not be in the bay area."
         </dd>
     </dl>
     <p>
@@ -48,6 +48,6 @@
     An expression can contain whitespace for better readability, and it'll be ignored.
 
     <p>
-    Label names or slave names can be quoted if they contain unsafe characters. For example,
+    Label names or agent names can be quoted if they contain unsafe characters. For example,
     <tt>"jenkins-solaris (Solaris)" || "Windows 2008"</tt>
 </div>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
@@ -45,7 +45,7 @@
                        checked="${instance.assignedLabelString!=null}" inline="true">
         <f:entry title="${%Label Expression}"
                  description="If not set, the label of the promoted build will be used." field="assignedLabelString">
-          <f:textbox autoCompleteDelimChar=" " name="assignedLabelString" value="${instance.assignedLabelString}" autoCompleteField="assignedLabelString"/>
+          <f:textbox autoCompleteDelimChar=" "/>
         </f:entry>
       </f:optionalBlock>
 

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionProcess/process-config.jelly
@@ -44,7 +44,7 @@
       <f:optionalBlock name="hasAssignedLabel" title="${%Restrict where this promotion process can be run}"
                        checked="${instance.assignedLabelString!=null}" inline="true">
         <f:entry title="${%Label Expression}"
-                 description="If not set, the label of the promoted build will be used.">
+                 description="If not set, the label of the promoted build will be used." field="assignedLabelString">
           <f:textbox autoCompleteDelimChar=" " name="assignedLabelString" value="${instance.assignedLabelString}" autoCompleteField="assignedLabelString"/>
         </f:entry>
       </f:optionalBlock>

--- a/src/test/resources/complex-example-dsl.groovy
+++ b/src/test/resources/complex-example-dsl.groovy
@@ -4,7 +4,7 @@ freeStyleJob('test-job-complex') {
             promotion {
                 name("Development")
                 icon("star-red")
-                restrict('slave1')
+                restrict('agent1')
                 conditions {
                     manual('testuser'){
                       parameters{
@@ -32,7 +32,7 @@ freeStyleJob('test-job-complex') {
             promotion {
                 name("Test")
                 icon("star-yellow")
-                restrict('slave2')
+                restrict('agent2')
                 conditions {
                     manual('testuser')
                     upstream("Development")


### PR DESCRIPTION
<!-- Please describe your pull request here -->

See [JENKINS-42816](https://issues.jenkins.io/browse/JENKINS-42816).
- use agent terminology
- the help message for label was not displayed, added the missing field value to have it displayed.

I have run tests locally, it seems ok

Screenshot of the help message (using `mvn hpi:run`):
![agent terminology](https://user-images.githubusercontent.com/3634942/116872089-96400200-ac15-11eb-8642-56421d0a19dd.png)


### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@mention

