### PR TITLE
Use newer `project-inheritance` dependency (19.08.02 instead of 1.5.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>hudson.plugins</groupId>
       <artifactId>project-inheritance</artifactId>
-      <version>1.5.3</version>
+      <version>19.08.02</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
As reported by @jtnord, otherwise tests fail with `-Djenkins.version=2.278` due to

```
java.util.concurrent.ExecutionException: java.lang.NoSuchMethodError: hudson.model.Queue$WaitingItem.getFuture()Ljava/util/concurrent/Future;
	at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:81)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1332)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatusSuccess(JenkinsRule.java:1361)
	at org.jvnet.hudson.test.JenkinsRule.buildAndAssertSuccess(JenkinsRule.java:1373)
	at hudson.plugins.promoted_builds.conditions.inheritance.DownstreamPassConditionInheritanceTest.shouldEvaluateUpstreamRecursively(DownstreamPassConditionInheritanceTest.java:66)
	at …
Caused by: java.lang.NoSuchMethodError: hudson.model.Queue$WaitingItem.getFuture()Ljava/util/concurrent/Future;
	at hudson.plugins.project_inheritance.projects.InheritanceProject.scheduleBuild2(InheritanceProject.java:1794)
	at hudson.model.AbstractProject.scheduleBuild2(AbstractProject.java:804)
	at hudson.model.AbstractProject.scheduleBuild(AbstractProject.java:792)
	at hudson.tasks.BuildTrigger.execute(BuildTrigger.java:277)
	at hudson.model.AbstractBuild$AbstractBuildExecution.cleanUp(AbstractBuild.java:713)
	at hudson.model.Build$BuildExecution.cleanUp(Build.java:192)
	at hudson.model.Run.execute(Run.java:1954)
	at hudson.plugins.project_inheritance.projects.InheritanceBuild.run(InheritanceBuild.java:139)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```

This dep was introduced in #75 but the plugin is not in @jenkinsci and shows a warning in the UC for almost a year due to an [unresolved vulnerability](https://www.jenkins.io/security/advisory/2020-06-03/#SECURITY-1582). There has been activity since then https://github.com/i-m-c/jenkins-inheritance-plugin/compare/ff1effd60cb0137112775d2330a49cf3d83e0a71...master but apparently not to fix the vulnerability. Suggest removing the integration here; the dependency would better be inverted anyway. @J-cztery @HedAurabesh

Root cause unclear, but perhaps due to https://github.com/jenkinsci/jenkins/pull/5232 and/or https://github.com/jenkinsci/jenkins/pull/5210 with https://github.com/infradna/bridge-method-injector/compare/bridge-method-injector-parent-1.13...bridge-method-injector-parent-1.18 @daniel-beck?
