### PR TITLE
Fixes JENKINS-49684 when adding any non-trivial step such as copyArtifact

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
@@ -104,7 +104,10 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
         writeNodeAttributes(node, writer);
         if (node.value() instanceof Collection) {
             for (Object subNode : (Collection) node.value()) {
-                convertNode((Node) subNode, writer);
+               if(subNode instanceof Node)
+            	   convertNode((Node) subNode, writer);
+               else
+            	   writer.setValue(String.valueOf(subNode));
             }
         } else {
             writer.setValue(node.value().toString());


### PR DESCRIPTION
<!-- Please describe your pull request here -->
When using the job dsl to create jobs that has any steps that are not trivial such as 
```
copyArtifact('jobName'){
            includePatterns('target/*.war')
            
            targetDirectory('target/')
            optional()
            buildSelector {
                specific {
                  buildNumber('$PROMOTED_NUMBER')
                }
            }
}
```

See [JENKINS-49684](https://issues.jenkins.io/browse/JENKINS-49684).

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [ ] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [ ] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [ ] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [ ] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [ ] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@jglick 
