### PR TITLE
Fix dynamic DSL plugins handling in job DSL

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/JobDslPromotionProcessConverter.java
@@ -87,24 +87,20 @@ public class JobDslPromotionProcessConverter extends ReflectionConverter {
 
     private void writeNodes(HierarchicalStreamWriter writer, List<Node> nodes) {
         for (Node node : nodes) {
-            writer.startNode(node.name().toString());
-            if (node.value() instanceof Collection) {
-                for (Object subNode : (Collection) node.value()) {
-                    convertNode((Node) subNode, writer);
-                }
-            } else {
-                writer.setValue(node.value().toString());
-            }
-            writer.endNode();
+            writeNode(node, writer);
         }
     }
 
-    private void convertNode(Node node, HierarchicalStreamWriter writer) {
+    private void writeNode(Node node, HierarchicalStreamWriter writer) {
         writer.startNode(node.name().toString());
         writeNodeAttributes(node, writer);
         if (node.value() instanceof Collection) {
             for (Object subNode : (Collection) node.value()) {
-                convertNode((Node) subNode, writer);
+                if (subNode instanceof Node) {
+                    writeNode((Node) subNode, writer);
+                } else {
+                    writer.setValue(subNode.toString());
+                }
             }
         } else {
             writer.setValue(node.value().toString());

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsDslContextExtensionTest.java
@@ -98,4 +98,20 @@ public class PromotionsDslContextExtensionTest {
                 .matcher(content).find());
     }
 
+    @Test
+    public void testShouldGenerateTheDynamicDslJob() throws Exception {
+        // Given
+        String dsl = FileUtils.readFileToString(new File("src/test/resources/dynamic-dsl-example-dsl.groovy"));
+        FreeStyleProject seedJob = j.createFreeStyleProject();
+        seedJob.getBuildersList().add(createScript(dsl));
+        // When
+        QueueTaskFuture<FreeStyleBuild> scheduleBuild2 = seedJob.scheduleBuild2(0);
+        j.assertBuildStatusSuccess(scheduleBuild2.get());
+
+        TopLevelItem item = j.jenkins.getItem("dynamic-dsl-test");
+        File config = new File(item.getRootDir(), "promotions/Development/config.xml");
+        String content = Files.toString(config, Charset.forName("UTF-8"));
+        assert content.contains("<javaposse.jobdsl.plugin.ExecuteDslScripts>");
+    }
+
 }

--- a/src/test/resources/dynamic-dsl-example-dsl.groovy
+++ b/src/test/resources/dynamic-dsl-example-dsl.groovy
@@ -1,0 +1,17 @@
+freeStyleJob('dynamic-dsl-test') {
+    properties {
+        promotions {
+            promotion {
+                name('Development')
+                conditions {
+                    manual('tester')
+                }
+                actions {
+                    jobDsl {
+                        scriptText('println test')
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit fixes working with dynamic DSL plugins in job DSL integration code, namely in promotion actions processing.

Currently an attempt to use a dynamic DSL plugin in promotion actions causes Jenkins to raise an exception because dynamic DSL plugin nodes seem to have a different layout than a regular job DSL plugin.
