### PR TITLE
fix test download of svg images

### DIFF
--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildActionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildActionTest.java
@@ -13,6 +13,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.IOException;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,9 +49,11 @@ public class PromotedBuildActionTest {
             } 
             HtmlImage img = (HtmlImage)candidate;
             try {
-                img.getHeight();
+                assertEquals("Failed to load " + img.getSrcAttribute(),
+                        200,
+                        img.getWebResponse(true).getStatusCode());
             } catch (IOException e) {
-                throw new IOException2("Failed to load "+img.getSrcAttribute(),e);
+                throw new AssertionError("Failed to load " + img.getSrcAttribute());
             }
         }
     }


### PR DESCRIPTION
<!-- Please describe your pull request here -->
PromotedBuildActionTest fails for jenkins versions > 2.221 due to UI change.
see https://github.com/jenkinsci/jenkins-test-harness/pull/200

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [ ] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [ ] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@jglick 

