### PR TITLE
[JENKINS-67045] Remove Promotion#getTarget

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,12 @@
-// Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+#!/usr/bin/env groovy
+
+buildPlugin(useContainerAgent: true,
+        configurations: [
+                [platform: 'linux', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
+
+                // testing the Guava & Guice bumps
+                // https://github.com/jenkinsci/jenkins/pull/5707
+                // https://github.com/jenkinsci/jenkins/pull/5858
+                //[ platform: "linux", jdk: "8", jenkins: '2.321', javaLevel: "8" ]
+        ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-buildPlugin(useContainerAgent: true,
+buildPlugin(useContainerAgent: false, // temporarily disable for Windows issues
         configurations: [
                 [platform: 'linux', jdk: '11'],
                 [platform: 'windows', jdk: '8'],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>4.33</version>
     <relativePath />
   </parent>
 
@@ -16,13 +16,11 @@
   <url>https://github.com/jenkinsci/promoted-builds-plugin</url>
 
   <properties>
-    <revision>3.12</revision>
+    <revision>4.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/promoted-builds-plugin</gitHubRepo>
-    <!-- Last version before https://jenkins.io/security/advisory/2018-08-15/ which causes instabilities
-         due to Promotion#getTarget(). And we cannot just remove it without breaking binary compatibility
-         (see JENKINS-59704, JENKINS-59773 and so on for the fallout in 3.4)-->
-    <jenkins.version>2.121.1</jenkins.version>
+    <bom>2.289.x</bom>
+    <jenkins.version>2.289.3</jenkins.version>
     <java.level>8</java.level>
     <findbugs.effort>Max</findbugs.effort>
     <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
@@ -69,11 +67,28 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${bom}</artifactId>
+        <version>987.v4ade2e49fe70</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.12.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>3.2</version>
+      <version>3.12</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>
@@ -85,12 +100,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
@@ -101,12 +114,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.19</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -117,18 +128,15 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
-      <version>2.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>hudson.plugins</groupId>
@@ -151,7 +159,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.54</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -169,7 +176,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>1.6</version>
       <scope>test</scope>
       <exclusions>
         <!-- Real Upper Bounds dependency issue,
@@ -183,7 +189,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -35,7 +35,6 @@ import hudson.tasks.BuildTrigger;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.export.Exported;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,7 +84,8 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
      */
     @CheckForNull
     public AbstractBuild<?,?> getTargetBuild() {
-        return getTarget();
+        PromotionTargetAction pta = getAction(PromotionTargetAction.class);
+        return pta == null ? null : pta.resolve(this);
     }
 
     /**
@@ -96,27 +96,13 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
      */
     @Nonnull
     public AbstractBuild<?,?> getTargetBuildOrFail() {
-        final AbstractBuild<?, ?> target = getTarget();
+        PromotionTargetAction pta = getAction(PromotionTargetAction.class);
+        final AbstractBuild<?, ?> target = pta == null ? null : pta.resolve(this);
         if (target == null) {
             throw new IllegalStateException("There is no target build associated with " + this +
                     ". Most probably, the build has been already removed");
         }
         return target;
-    }
-
-    /**
-     * Gets the build that this promotion promoted.
-     *
-     * @deprecated Use {@link #getTargetBuildOrFail()} or {@link #getTargetBuild()}. This method will be removed once the baseline is updated in Promoted Builds 4.0
-     * @return
-     *      null if there's no such object. For example, if the build has already garbage collected.
-     */
-    @Exported
-    @Deprecated
-    @CheckForNull
-    public AbstractBuild<?,?> getTarget() {
-        PromotionTargetAction pta = getAction(PromotionTargetAction.class);
-        return pta == null ? null : pta.resolve(this);
     }
 
     @Override public AbstractBuild<?,?> getRootBuild() {

--- a/src/test/java/hudson/plugins/promoted_builds/ConfigurationDoCheckTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/ConfigurationDoCheckTest.java
@@ -40,7 +40,7 @@ public class ConfigurationDoCheckTest {
         client.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         HtmlPage page = (HtmlPage) submit(client.getPage(p, "configure").getFormByName("config"));
-        assertTrue(page.asText().contains("No name is specified"));
+        assertTrue(page.getVisibleText().contains("No name is specified"));
 
     }
 
@@ -63,7 +63,7 @@ public class ConfigurationDoCheckTest {
         client.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         HtmlPage page = (HtmlPage) submit(client.getPage(p, "configure").getFormByName("config"));
-        assertTrue(page.asText().contains("unsafe character"));
+        assertTrue(page.getVisibleText().contains("unsafe character"));
 
     }
 }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionTest.java
@@ -36,12 +36,16 @@ import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.net.URL;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 public class PromotionTest {
 
@@ -101,7 +105,7 @@ public class PromotionTest {
         assertSame(pb.getTargetBuildOrFail(), b);
 
         JenkinsRule.WebClient wc = r.createWebClient();
-        final Page page = wc.getPage( r.getURL() + "/" + pb.getUrl() + "consoleText");// spot-check that promotion itself is accessible
+        final Page page = wc.goTo(pb.getUrl() + "consoleText", "text/plain");// spot-check that promotion itself is accessible
         assertThat(pb.getUrl() + "/consoleText + is not a promotion log", page.getWebResponse().getContentAsString(), CoreMatchers.containsString("ABCDEFGH"));
     }
 


### PR DESCRIPTION
Refile of https://github.com/jenkinsci/promoted-builds-plugin/pull/158 as a maintainer to add Jenkinsfile refinements

Update build infrastructure for compatibility with JDK11. This requires to remove Promotion#getTarget as it conflicts with evolutions done in Jenkins core.

Downstream plugins will need to adjust to this.


<!-- Please describe your pull request here -->

See [JENKINS-67045](JENKINS-67045).

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->
