### PR TITLE
Restore missing icon for failed promotions

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotionStatusColumn/column.jelly
@@ -16,10 +16,8 @@
 	          <j:choose>
 	            <j:when test="${status!=null}">
 	              <j:if test="${status.isLastAnError()}">
-	                <j:set var="iconUrl" value="${resURL}/images/${iconSize}/error.png"/>
-	                <img width="${iconSize}" height="${iconSize}"
-	                  title="${%PromotionProcess} ${process.name} ${%PromotionProcess.failed}"
-	                  src="${iconUrl}"/>
+	                <l:icon title="${%PromotionProcess} ${process.name} ${%PromotionProcess.failed}"
+	                  class="icon-error ${subIconSizeClass}"/>
 	              </j:if>
 	              <j:set var="target" value="${status.getTarget()}"/>
 	              <a href="${jobBaseUrl}${job.shortUrl}${target.number}/" class="model-link inside">


### PR DESCRIPTION
<!-- Please describe your pull request here -->

See [JENKINS-68320](https://issues.jenkins.io/browse/JENKINS-68320)

The change proposed adapts the icon path removal from core by using the icon size class in table views.