### PR TITLE
Force lazy loading of Promoted Builds Plugin properties so they are available to JCasC

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -57,6 +57,10 @@ import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
 /**
  * Records a promotion process.
  *
@@ -485,6 +489,16 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
 
     public static final PermissionGroup PERMISSIONS = new PermissionGroup(Promotion.class, Messages._Promotion_Permissions_Title());
     public static final Permission PROMOTE = new Permission(PERMISSIONS, "Promote", Messages._Promotion_PromotePermission_Description(), Jenkins.ADMINISTER, PermissionScope.RUN);
+
+    @Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    @Restricted(DoNotUse.class)
+    public static void registerPermissions() {
+    // Pending JENKINS-17200, ensure that the above permissions have been registered prior to
+    // allowing plugins to adapt the system configuration, which may depend on these permissions
+    // having been registered. Since this method is static and since it follows the above
+    // construction of static permission objects (and therefore their calls to
+    // PermissionGroup#register), there is nothing further to do in this method.
+    }
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
<!-- Please describe your pull request here -->

- Given [JENKINS-17200](https://issues.jenkins-ci.org/browse/JENKINS-17200) is currently unfixed we are forcing eager loading of properties relevant to Promoted Builds Plugin so that they are available to the JcasC. 
- Prior to this eager load the `Promote` property was unavailable for in the Global Security Matrix. 

### References
- An similar fix made within core Jenkins to fix property loading: https://github.com/jenkinsci/jenkins/pull/5723
- Discussion between Slack developers and Jenkins collaborators which led us to this fix: https://github.com/jenkinsci/configuration-as-code-plugin/issues/2005

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [✅] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [✅] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [✅] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [❌] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [❌] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [❌] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

CC: 
@car-roll @raul-arabaolaza @oleg-nenashev @jglick 