### PR TITLE
Optimize Gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,0 @@
-FROM gitpod/workspace-full
-
-USER gitpod
-
-RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
-    sdk install java 17.0.3-tem && \
-    sdk install java 11.0.15-tem  && \
-    sdk default java 17.0.3-tem"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,5 @@
-# Using an updated Gitpod docker image (when using a non default JDK or tools)
-image:
-  file: .gitpod.Dockerfile
-
 tasks:
-  - init: sdk default java  11.0.15-tem && mvn clean verify
+  - init: mvn clean verify
 
 vscode:
   extensions:


### PR DESCRIPTION
Removes the multiple JDKs installations in Gitpod as Java17 is not a requirement anymore for VSC plugins.

