### PR TITLE
chore(dependencies): Require 2.387.3 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
     <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.375.3</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
   </properties>
@@ -68,7 +68,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>2179.v0884e842b_859</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
#247 fails because the dependency `org.jenkins-ci.plugins:parameterized-trigger:jar:2.46` requires Jenkins `2.387.3` or higher.

I propose then to amend the dependabot PR with this one.

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [X] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [X] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [X] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- ~~Test automation, if relevant. We expect autotests for all new features or complex bugfixes~~
- ~~Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files~~
- ~~Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html))~~

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@mention

