### PR TITLE
[JENKINS-69711] Promotion configuration is lost when creating a new job by copy

### DIFF
--- a/src/main/java/hudson/plugins/promoted_builds/CopyListener.java
+++ b/src/main/java/hudson/plugins/promoted_builds/CopyListener.java
@@ -37,9 +37,11 @@ public class CopyListener extends ItemListener {
             if (subdirs != null) {
                 prop = ((Job<?,?>)item).getProperty(JobPropertyImpl.class);
                 for (File subdir : subdirs) try {
+                    File dest = prop.getRootDirFor(subdir.getName());
+                    Files.createDirectories(dest.toPath());
                     Files.copy(
                             new File(subdir, "config.xml").toPath(),
-                            new File(prop.getRootDirFor(subdir.getName()), "config.xml").toPath(),
+                            new File(dest, "config.xml").toPath(),
                             StandardCopyOption.REPLACE_EXISTING);
                 } catch (InvalidPathException | IOException e) {
                     Logger.getLogger(CopyListener.class.getName()).log(Level.WARNING,


### PR DESCRIPTION
See [JENKINS-69711](https://issues.jenkins.io/browse/JENKINS-69711). Fixes a regression introduced in https://github.com/jenkinsci/promoted-builds-plugin/pull/217. Tested by reproducing the problem as described in the bug and verifying the problem was no longer reproducible after this PR.