### PR TITLE
improve the UIX promotions page

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -28,7 +28,7 @@
                   <td>
                     <a href="${p.name}/promotionBuild/${attempt.number}/console">
                       <l:icon class="${attempt.iconColor.iconClassName} icon-sm"
-                       alt="${attempt.iconColor.description}"/> ${attempt.displayName} (${attempt.timestamp.time})
+                        alt="${attempt.iconColor.description}"/> ${attempt.displayName} (${attempt.timestamp.time})
                     </a> by ${attempt.userName}
                   </td>
                 </tr>

--- a/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/PromotedBuildAction/index.jelly
@@ -16,6 +16,7 @@
         <!-- list promotions that are already attained -->
         <j:forEach var="p" items="${it.promotions}">
           <j:if test="${p.getProcess()!=null and p.getProcess().isVisible()}">
+            <div class="promotion">
             <h2>
               <img src="${resURL}/plugin/promoted-builds/icons/${p.getProcess().getIcon()}.svg" height="32px"/>
               <a href="../../promotion/process/${p.name}" class="model-link">${p.name}</a>
@@ -86,11 +87,13 @@
               </j:choose>
             </div>
             <div style="clear:both" />
+            </div>
           </j:if>
         </j:forEach>
         <!-- list promotions that are not yet attained -->
         <j:forEach var="p" items="${it.pendingPromotions}">
           <j:if test="${p.isVisible()}">
+            <div class="promotion">
             <h2>
               <img src="${resURL}/plugin/promoted-builds/icons/${p.getIcon()}.svg" height="32px"/>
               <a href="../../promotion/process/${p.name}" class="model-link">${p.name}</a>
@@ -124,6 +127,7 @@
               <j:set var="pba" value="${it}"/>
               <st:include it="${c}" page="index.jelly" />
             </j:forEach>
+            </div>
           </j:if>
         </j:forEach>
       </div>

--- a/src/main/webapp/css/promoted-builds.css
+++ b/src/main/webapp/css/promoted-builds.css
@@ -1,3 +1,9 @@
+.promotion {
+  box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.1) 0px 4px 6px -4px;
+  padding: 16px;
+  margin: 16px 4px;
+}
+
 .promoted-builds {
   overflow: hidden;
 }


### PR DESCRIPTION
<!-- Please describe your pull request here -->
In the GUI of the promotions page , there is no clear separation between the various promotions, and sometimes you may press the wrong one. 

This PR adds a container to the various sections of the page, changing the style as seen in the images below

## before
![jenkins-promotions-ugly](https://github.com/jenkinsci/promoted-builds-plugin/assets/13762470/10fe80e9-687d-4a77-b4f9-2f17422f6083)

## after
![jenkins-promotions](https://github.com/jenkinsci/promoted-builds-plugin/assets/13762470/9f5d00e0-9674-483f-9562-af587cc2d851)


See [JENKINS-72461](https://issues.jenkins-ci.org/browse/JENKINS-72461).

### Your checklist for this pull request

<!-- TODO: Reference contribution guidelines. https://issues.jenkins-ci.org/browse/JENKINS-57983 -->

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

<!-- Mention GitHub users or teams who could contribute to the review -->

@mention

