### PR TITLE
Replace EOL spinner.gif with drop-in Jelly tag

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds/Promotion/index.jelly
@@ -26,7 +26,7 @@
         <j:when test="${it.building}">
           <pre id="out"></pre>
           <div id="spinner">
-            <img src="${imagesURL}/spinner.gif" />
+            <l:progressAnimation/>
           </div>
           <t:progressiveText href="progressiveLog" idref="out" spinner="spinner" />
         </j:when>


### PR DESCRIPTION
The change proposed replaces the EOL spinner.gif with the drop-in Jelly tag replacement.