### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
   </properties>
@@ -68,8 +68,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>3289.v3ff9637cd241</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -81,12 +81,6 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-net</groupId>
-          <artifactId>commons-net</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -106,16 +100,6 @@
       <artifactId>structs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>token-macro</artifactId>
       <optional>true</optional>
@@ -133,12 +117,6 @@
       <artifactId>job-dsl</artifactId>
       <version>1.87</version>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -150,7 +128,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <!-- TODO: it is something insane, no? -->
+      <!-- Needed for Job DSL test -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
       <scope>test</scope>

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionCondition.java
@@ -29,6 +29,7 @@ public abstract class PromotionCondition implements ExtensionPoint, Describable<
      * @deprecated
      */
     @CheckForNull
+    @Deprecated
     public PromotionBadge isMet(AbstractBuild<?,?> build) {
         return null;
     }

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -467,6 +467,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @deprecated
      *      Use {@link #promote2(AbstractBuild, Cause, Status)}
      */
+    @Deprecated
     public void promote(AbstractBuild<?,?> build, Cause cause, Status qualification) throws IOException {
         promote2(build,cause,qualification);
     }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -153,6 +153,7 @@ public class DownstreamPassCondition extends PromotionCondition {
     /**
      * @deprecated use {@link #contains(hudson.model.ItemGroup, hudson.model.AbstractProject, hudson.EnvVars)} 
      */
+    @Deprecated
     public boolean contains(ItemGroup ctx, AbstractProject<?,?> job){
         return contains(ctx, job, null);
     }
@@ -181,6 +182,7 @@ public class DownstreamPassCondition extends PromotionCondition {
      * Short-cut for {@code getJobList().contains(job)}.
      * @deprecated use {@link #contains(hudson.model.ItemGroup, hudson.model.AbstractProject)}
      */
+    @Deprecated
     public boolean contains(AbstractProject<?,?> job) {
         return contains(Jenkins.get(), job);
     }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
@@ -81,7 +81,11 @@ public class PromotedBuildRebuildParameterProviderTest {
         Assert.assertEquals(b1.getNumber(), pbpv1.getRun().getNumber());
 
         // rebuild it
-        FreeStyleBuild b3 = j.assertBuildStatusSuccess(p2.scheduleBuild2(0));
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage buildPage = wc.getPage(b2);
+        HtmlPage rebuildConfigPage = buildPage.getAnchorByText("Rebuild").click();
+        j.submit(rebuildConfigPage.getFormByName("config"));
+        j.waitUntilNoActivity();
 
         // validate presence of parameter
         FreeStyleBuild rebuild = p2.getLastBuild();

--- a/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotedBuildRebuildParameterProviderTest.java
@@ -81,11 +81,7 @@ public class PromotedBuildRebuildParameterProviderTest {
         Assert.assertEquals(b1.getNumber(), pbpv1.getRun().getNumber());
 
         // rebuild it
-        JenkinsRule.WebClient wc = j.createWebClient();
-        HtmlPage page = wc.getPage(b2, "rebuild");
-        HtmlForm form = page.getFormByName("config");
-        j.submit(form);
-        j.waitUntilNoActivity();
+        FreeStyleBuild b3 = j.assertBuildStatusSuccess(p2.scheduleBuild2(0));
 
         // validate presence of parameter
         FreeStyleBuild rebuild = p2.getLastBuild();


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

[Installation statistics](https://stats.jenkins.io/pluginversions/promoted-builds.html) show that 85% of the installations of the most recent release (delivered 3 months ago) are already running Jenkins 2.440.3 or newer.  Users that are upgrading to the most recent release of the plugin are also upgrading to the most recent Jenkins releases.

Removes unnecessary declarations of mockito-core and hamcrest since those are provided by the parent pom.

Removes unnecessary exclusions from other dependencies.

Annotates deprecated methods to silence compiler warnings

Replace rebuild web action in test with freestyle build

Intentionally sacrifices some code coverage of the rebuild plugin so that I don't need to find an alternate way to invoke rebuild.  The previously tested web action is intentionally disallowed by SECURITY-3033 as implemented in:

* https://github.com/jenkinsci/rebuild-plugin/pull/155

### Your checklist for this pull request

- [x] Pull request title represents the changelog entry which will be used in Release Notes. JIRA issue is a part of the title (see existing PRs as examples)
- [x] Please describe what you did. Short summary for reviewers. If the change involves WebUI, add screenshots 
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org) or pull requests
- [x] Test automation, if relevant. We expect autotests for all new features or complex bugfixes
- [x] Documentation if relevant (new features). We want to use Documentation-as-Code, just put docs to README or to new Doc files
- [x] Javadoc for new APIs. Any public/protected method is considered as API unless annotated by `Restricted` ([docs](https://kohsuke.org/access-modifier/apidocs/org/kohsuke/accmod/AccessRestriction.html)) 

### CC

@basil
