### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -18,8 +18,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>
   </properties>
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3435.v238d66a_043fb_</version>
+        <version>3893.v213a_42768d35</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds.java
+++ b/src/main/java/hudson/plugins/promoted_builds/GlobalBuildPromotedBuilds.java
@@ -3,7 +3,7 @@ package hudson.plugins.promoted_builds;
 import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Global Jenkins configuration for Promoted Builds
@@ -33,7 +33,7 @@ public class GlobalBuildPromotedBuilds extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         save();
         return true;

--- a/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
+++ b/src/main/java/hudson/plugins/promoted_builds/JobPropertyImpl.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Ancestor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import hudson.Extension;
 import hudson.Util;
@@ -94,7 +94,7 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
         this.activeProcessNames.addAll(activeProcessNames);
     }
 
-    private JobPropertyImpl(StaplerRequest req, JSONObject json) throws Descriptor.FormException, IOException {
+    private JobPropertyImpl(StaplerRequest2 req, JSONObject json) throws Descriptor.FormException, IOException {
         // a hack to get the owning AbstractProject.
         // this is needed here so that we can load items
         List<Ancestor> ancs = req.getAncestors();
@@ -416,7 +416,7 @@ public final class JobPropertyImpl extends JobProperty<AbstractProject<?,?>> imp
         }
 
         @Override
-        public JobPropertyImpl newInstance(StaplerRequest req, JSONObject json) throws Descriptor.FormException {
+        public JobPropertyImpl newInstance(StaplerRequest2 req, JSONObject json) throws Descriptor.FormException {
             try {
                 if(json.has("promotions"))
                     return new JobPropertyImpl(req, json);

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedBuildAction.java
@@ -11,8 +11,8 @@ import hudson.util.CopyOnWriteList;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -218,7 +218,7 @@ public final class PromotedBuildAction implements BuildBadgeAction {
     /**
      * Binds {@link Status} to URL hierarchy by its name.
      */
-    public Status getDynamic(String name, StaplerRequest req, StaplerResponse rsp) {
+    public Status getDynamic(String name, StaplerRequest2 req, StaplerResponse2 rsp) {
         return getPromotion(name);
     }
 

--- a/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotedProjectAction.java
@@ -11,7 +11,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -132,7 +132,7 @@ public class PromotedProjectAction implements ProminentProjectAction, PermalinkP
     }
 
     @RequirePOST
-    public HttpResponse doCreateProcess(@QueryParameter String name, StaplerRequest req) throws IOException {
+    public HttpResponse doCreateProcess(@QueryParameter String name, StaplerRequest2 req) throws IOException {
         property.createProcessFromXml(name, req.getInputStream());
         return HttpResponses.ok();
     }

--- a/src/main/java/hudson/plugins/promoted_builds/Promotion.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Promotion.java
@@ -54,8 +54,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -306,7 +306,7 @@ public class Promotion extends AbstractBuild<PromotionProcess,Promotion> {
     	return definitions;
     }
 
-    public void doRebuild(StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public void doRebuild(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         throw HttpResponses.error(404, "Promotions may not be rebuilt directly");
     }
 

--- a/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
+++ b/src/main/java/hudson/plugins/promoted_builds/PromotionProcess.java
@@ -47,10 +47,10 @@ import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -118,7 +118,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
      * @throws IOException {@link PromotionProcess} creation issue
      * @return Parsed promotion process
      */
-    public static PromotionProcess fromJson(StaplerRequest req, JSONObject o) throws FormException, IOException {
+    public static PromotionProcess fromJson(StaplerRequest2 req, JSONObject o) throws FormException, IOException {
         String name = o.getString("name");
         try {
             Jenkins.checkGoodName(name);
@@ -140,7 +140,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
         super.doSetName(name);
     }
 
-    /*package*/ void configure(StaplerRequest req, JSONObject c) throws Descriptor.FormException, IOException {
+    /*package*/ void configure(StaplerRequest2 req, JSONObject c) throws Descriptor.FormException, IOException {
         // apply configuration
         conditions.rebuild(req,c.optJSONObject("conditions"), PromotionCondition.all());
 
@@ -553,7 +553,7 @@ public final class PromotionProcess extends AbstractProject<PromotionProcess,Pro
 
 
     @Override
-    public void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
+    public void doBuild(StaplerRequest2 req, StaplerResponse2 rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
         throw HttpResponses.error(404, "Promotion processes may not be built directly");
     }
 

--- a/src/main/java/hudson/plugins/promoted_builds/Status.java
+++ b/src/main/java/hudson/plugins/promoted_builds/Status.java
@@ -15,10 +15,10 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -386,7 +386,7 @@ public final class Status {
      * @throws ServletException Request handling error
      */
     @POST
-    public void doBuild(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public void doBuild(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         
         final PromotionProcess process = getProcess();
         if (process == null) {

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/DownstreamPassCondition.java
@@ -30,7 +30,7 @@ import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -209,7 +209,7 @@ public class DownstreamPassCondition extends PromotionCondition {
             return Messages.DownstreamPassCondition_DisplayName();
         }
 
-        public PromotionCondition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public PromotionCondition newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return new DownstreamPassCondition(
                     formData.getString("jobs"), formData.getBoolean("evenIfUnstable"));
         }

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/ManualCondition.java
@@ -27,15 +27,15 @@ import java.util.concurrent.Future;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.acegisecurity.GrantedAuthority;
 import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.verb.POST;
 
@@ -194,7 +194,7 @@ public class ManualCondition extends PromotionCondition {
      * Web method to handle the approval action submitted by the user.
      */
     @POST
-    public void doApprove(StaplerRequest req, StaplerResponse rsp,
+    public void doApprove(StaplerRequest2 req, StaplerResponse2 rsp,
             @AncestorInPath PromotionProcess promotionProcess,
             @AncestorInPath AbstractBuild<?,?> build) throws IOException, ServletException {
 
@@ -304,7 +304,7 @@ public class ManualCondition extends PromotionCondition {
         }
 
         @Override
-        public ManualCondition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public ManualCondition newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             ManualCondition instance = new ManualCondition();
             instance.users = formData.getString("users");
             instance.parameterDefinitions = Descriptor.newInstancesFromHeteroList(req, formData, "parameters", ParameterDefinition.all());

--- a/src/main/java/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/conditions/UpstreamPromotionCondition.java
@@ -10,7 +10,7 @@ import hudson.plugins.promoted_builds.PromotionConditionDescriptor;
 import hudson.plugins.promoted_builds.PromotionProcess;
 import hudson.plugins.promoted_builds.Status;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,7 +95,7 @@ public class UpstreamPromotionCondition extends PromotionCondition {
             return Messages.UpstreamPromotionCondition_DisplayName();
         }
 
-        public PromotionCondition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public PromotionCondition newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return new UpstreamPromotionCondition(
                     formData.getString("promotions"));
         }

--- a/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
+++ b/src/main/java/hudson/plugins/promoted_builds/parameters/PromotedBuildParameterDefinition.java
@@ -54,7 +54,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -85,7 +85,7 @@ public class PromotedBuildParameterDefinition extends SimpleParameterDefinition 
     }
 
     @Override
-    public PromotedBuildParameterValue createValue(StaplerRequest req, JSONObject jo) {
+    public PromotedBuildParameterValue createValue(StaplerRequest2 req, JSONObject jo) {
         PromotedBuildParameterValue value = req.bindJSON(PromotedBuildParameterValue.class, jo);
         value.setPromotionProcessName(promotionProcessName);
         value.setDescription(getDescription());
@@ -136,15 +136,15 @@ public class PromotedBuildParameterDefinition extends SimpleParameterDefinition 
      * Gets a list of promoted builds for the project.
      * @return List of {@link AbstractBuild}s, which have been promoted
      * @deprecated This method retrieves the base item for relative addressing from 
-     * the {@link StaplerRequest}. The relative addressing may be malfunctional if
-     * you use this method outside {@link StaplerRequest}s. 
+     * the {@link StaplerRequest2}. The relative addressing may be malfunctional if
+     * you use this method outside {@link StaplerRequest2}s. 
      * Use {@link #getRuns(hudson.model.Item)} instead
      */
     @NonNull
     @Deprecated
     public List getBuilds() {
         // Try to get ancestor from the object, otherwise pass null and disable the relative addressing
-        final StaplerRequest currentRequest = Stapler.getCurrentRequest();
+        final StaplerRequest2 currentRequest = Stapler.getCurrentRequest2();
         final Item item = currentRequest != null ? currentRequest.findAncestorObject(Item.class) : null;
         return getRuns(item);
     }
@@ -202,7 +202,7 @@ public class PromotedBuildParameterDefinition extends SimpleParameterDefinition 
         }
 
         @Override
-        public ParameterDefinition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public ParameterDefinition newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(PromotedBuildParameterDefinition.class, formData);
         }
         

--- a/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
+++ b/src/main/java/hudson/plugins/promoted_builds/tasks/RedeployBatchTaskPublisher.java
@@ -10,7 +10,7 @@ import hudson.plugins.promoted_builds.Promotion;
 import hudson.plugins.promoted_builds.PromotionProcess;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * {@link RedeployPublisher} altered for batch task.
@@ -37,7 +37,7 @@ public class RedeployBatchTaskPublisher extends RedeployPublisher {
 
         @SuppressFBWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
         @Override
-        public RedeployPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public RedeployPublisher newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return req.bindJSON(RedeployBatchTaskPublisher.class,formData);
         }
     }

--- a/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/PromotionProcessTest.java
@@ -157,7 +157,7 @@ public class PromotionProcessTest {
                     .accumulate("conditions",new JSONObject()
                         .accumulate("hudson-plugins-promoted_builds-conditions-SelfPromotionCondition",
                                 new JSONObject().accumulate("evenIfUnstable", false)));
-            PromotionProcess p = PromotionProcess.fromJson(Stapler.getCurrentRequest(), o);
+            PromotionProcess p = PromotionProcess.fromJson(Stapler.getCurrentRequest2(), o);
             assertEquals("foo", p.getName());
             assertEquals("star-gold", p.getIcon());
             assertEquals(1, p.conditions.size());


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.